### PR TITLE
set debug=true in Cargo.toml for release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,6 @@ branch= "pmarks/linking"
 
 [build-dependencies]
 prost-build = "0.5.0"
+
+[profile.release]
+debug = true


### PR DESCRIPTION
When I created the enclone repo, I accidentally forgot to copy these lines
[profile.release]
debug = true
into Cargo.toml.  Now I've put them in.  Without this, tracebacks are terrible.