### PR TITLE
fix version string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,6 +349,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +503,7 @@ dependencies = [
  "bio 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "debruijn 0.3.0 (git+https://github.com/10XGenomics/rust-debruijn.git)",
  "equiv 0.1.0 (git+https://github.com/10XGenomics/rust-toolbox.git)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1939,6 +1950,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "treeline"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2237,6 +2257,7 @@ dependencies = [
 "checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chashmap 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ff41a3c2c1e39921b9003de14bf0439c7b63a9039637c291e1a64925d8ddfa45"
+"checksum chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
@@ -2413,6 +2434,7 @@ dependencies = [
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+"checksum time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 "checksum treeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "enclone"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "amino 0.1.0 (git+https://github.com/10XGenomics/rust-toolbox.git)",
  "ansi_escape 0.1.0 (git+https://github.com/10XGenomics/rust-toolbox.git)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ attohttpc = { version = "0.12", default-features = false, features = ["compress"
 flate2 = "1.0.12"
 
 [build-dependencies]
+chrono = "0.4.11"
 prost-build = "0.5.0"
 string_utils = "0.1.1"
 

--- a/build.rs
+++ b/build.rs
@@ -4,9 +4,11 @@
 // printed out at appropriate points by enclone.  This files is a slightly modified version
 // of https://vallentin.dev/2019/06/06/versioning.
 
+extern crate chrono;
 extern crate prost_build;
 extern crate string_utils;
 
+use chrono::prelude::*;
 use prost_build::Config;
 use std::env::consts::{ARCH, OS};
 use std::process::Command;
@@ -58,22 +60,11 @@ fn is_github() -> bool {
     }
 }
 
-fn get_commit_date() -> String {
-    match std::env::var("GITHUB_SHA") {
-        Ok(_) => return "DATE".into(),
-        _ => (),
-    }
+// We used to have the commit date here but this is easier and serves the same purpose for
+// the version string.
 
-    let output = Command::new("git")
-        .arg("log")
-        .arg("-1")
-        .arg("--pretty=format:%ci") // Committer date, ISO 8601-like format
-        .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .output()
-        .unwrap();
-    assert!(output.status.success());
-    let s = String::from_utf8_lossy(&output.stdout).to_string();
-    s.before(" ").to_string()
+fn get_commit_date() -> String {
+    Local::now().to_string().before(" ").to_string()
 }
 
 fn get_branch_name() -> String {

--- a/build.rs
+++ b/build.rs
@@ -67,7 +67,7 @@ fn get_commit_date() -> String {
     let output = Command::new("git")
         .arg("log")
         .arg("-1")
-        .arg("--pretty=format:%ci") // Committer data, ISO 8601-like format
+        .arg("--pretty=format:%ci") // Committer date, ISO 8601-like format
         .current_dir(env!("CARGO_MANIFEST_DIR"))
         .output()
         .unwrap();

--- a/build.rs
+++ b/build.rs
@@ -36,7 +36,7 @@ fn main() {
 
 fn get_commit_hash() -> String {
     match std::env::var("GITHUB_SHA") {
-        Ok(v) => return v,
+        Ok(v) => return v[0..7].to_string(),
         _ => (),
     }
 


### PR DESCRIPTION
`enclone --version` should yield output like this

`0.2.5 : dj/31 : ef64055+ : 2020-04-29 : debug : linux : x86_64`

however the current release yields

`0.2.5 : refs/tags/v0.2.5 : a36007cf971c8c05e258782fbbd0c59456ed86e7 : DATE : release : linux : x86_64`

which has two problems
1. The sha is not truncated.
2. The date is replaced by the string DATE.

This should fix problem 1, but has not been tested.

**How can we fix problem 2?**