### PR TITLE
fix stuff on site (WORK IN PROGRESS)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 [[package]]
 name = "align_tools"
 version = "0.1.0"
-source = "git+https://github.com/10XGenomics/rust-toolbox.git#eb863f69a3f979fa30ed4667e5f354a20845950c"
+source = "git+https://github.com/10XGenomics/rust-toolbox.git#5e6587e01cee9d93227e40f267f96efbbbd79161"
 dependencies = [
  "bio 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "debruijn 0.3.0 (git+https://github.com/10XGenomics/rust-debruijn.git)",
@@ -27,7 +27,7 @@ dependencies = [
 [[package]]
 name = "amino"
 version = "0.1.0"
-source = "git+https://github.com/10XGenomics/rust-toolbox.git#eb863f69a3f979fa30ed4667e5f354a20845950c"
+source = "git+https://github.com/10XGenomics/rust-toolbox.git#5e6587e01cee9d93227e40f267f96efbbbd79161"
 dependencies = [
  "debruijn 0.3.0 (git+https://github.com/10XGenomics/rust-debruijn.git)",
 ]
@@ -35,7 +35,7 @@ dependencies = [
 [[package]]
 name = "ansi_escape"
 version = "0.1.0"
-source = "git+https://github.com/10XGenomics/rust-toolbox.git#eb863f69a3f979fa30ed4667e5f354a20845950c"
+source = "git+https://github.com/10XGenomics/rust-toolbox.git#5e6587e01cee9d93227e40f267f96efbbbd79161"
 dependencies = [
  "string_utils 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vector_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -121,7 +121,7 @@ dependencies = [
 [[package]]
 name = "binary_vec_io"
 version = "0.1.0"
-source = "git+https://github.com/10XGenomics/rust-toolbox.git#eb863f69a3f979fa30ed4667e5f354a20845950c"
+source = "git+https://github.com/10XGenomics/rust-toolbox.git#5e6587e01cee9d93227e40f267f96efbbbd79161"
 dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -449,7 +449,7 @@ dependencies = [
  "bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "boomphf 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "equiv"
 version = "0.1.0"
-source = "git+https://github.com/10XGenomics/rust-toolbox.git#eb863f69a3f979fa30ed4667e5f354a20845950c"
+source = "git+https://github.com/10XGenomics/rust-toolbox.git#5e6587e01cee9d93227e40f267f96efbbbd79161"
 
 [[package]]
 name = "errno"
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "exons"
 version = "0.1.0"
-source = "git+https://github.com/10XGenomics/rust-toolbox.git#eb863f69a3f979fa30ed4667e5f354a20845950c"
+source = "git+https://github.com/10XGenomics/rust-toolbox.git#5e6587e01cee9d93227e40f267f96efbbbd79161"
 dependencies = [
  "io_utils 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_utils 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -607,7 +607,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "fasta"
 version = "0.1.0"
-source = "git+https://github.com/10XGenomics/rust-toolbox.git#eb863f69a3f979fa30ed4667e5f354a20845950c"
+source = "git+https://github.com/10XGenomics/rust-toolbox.git#5e6587e01cee9d93227e40f267f96efbbbd79161"
 dependencies = [
  "debruijn 0.3.0 (git+https://github.com/10XGenomics/rust-debruijn.git)",
  "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -696,7 +696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "graph_simple"
 version = "0.1.0"
-source = "git+https://github.com/10XGenomics/rust-toolbox.git#eb863f69a3f979fa30ed4667e5f354a20845950c"
+source = "git+https://github.com/10XGenomics/rust-toolbox.git#5e6587e01cee9d93227e40f267f96efbbbd79161"
 dependencies = [
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "vector_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "hyper"
 version = "0.1.0"
-source = "git+https://github.com/10XGenomics/rust-toolbox.git#eb863f69a3f979fa30ed4667e5f354a20845950c"
+source = "git+https://github.com/10XGenomics/rust-toolbox.git#5e6587e01cee9d93227e40f267f96efbbbd79161"
 dependencies = [
  "debruijn 0.3.0 (git+https://github.com/10XGenomics/rust-debruijn.git)",
  "equiv 0.1.0 (git+https://github.com/10XGenomics/rust-toolbox.git)",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "kmer_lookup"
 version = "0.1.0"
-source = "git+https://github.com/10XGenomics/rust-toolbox.git#eb863f69a3f979fa30ed4667e5f354a20845950c"
+source = "git+https://github.com/10XGenomics/rust-toolbox.git#5e6587e01cee9d93227e40f267f96efbbbd79161"
 dependencies = [
  "debruijn 0.3.0 (git+https://github.com/10XGenomics/rust-debruijn.git)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -930,7 +930,7 @@ dependencies = [
 [[package]]
 name = "marsoc"
 version = "0.1.0"
-source = "git+https://github.com/10XGenomics/rust-toolbox.git#eb863f69a3f979fa30ed4667e5f354a20845950c"
+source = "git+https://github.com/10XGenomics/rust-toolbox.git#5e6587e01cee9d93227e40f267f96efbbbd79161"
 dependencies = [
  "io_utils 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_utils 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -983,7 +983,7 @@ dependencies = [
 [[package]]
 name = "mirror_sparse_matrix"
 version = "0.1.0"
-source = "git+https://github.com/10XGenomics/rust-toolbox.git#eb863f69a3f979fa30ed4667e5f354a20845950c"
+source = "git+https://github.com/10XGenomics/rust-toolbox.git#5e6587e01cee9d93227e40f267f96efbbbd79161"
 dependencies = [
  "binary_vec_io 0.1.0 (git+https://github.com/10XGenomics/rust-toolbox.git)",
  "io_utils 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1200,7 +1200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "perf_stats"
 version = "0.1.0"
-source = "git+https://github.com/10XGenomics/rust-toolbox.git#eb863f69a3f979fa30ed4667e5f354a20845950c"
+source = "git+https://github.com/10XGenomics/rust-toolbox.git#5e6587e01cee9d93227e40f267f96efbbbd79161"
 dependencies = [
  "io_utils 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1890,7 +1890,7 @@ dependencies = [
 [[package]]
 name = "tables"
 version = "0.1.0"
-source = "git+https://github.com/10XGenomics/rust-toolbox.git#eb863f69a3f979fa30ed4667e5f354a20845950c"
+source = "git+https://github.com/10XGenomics/rust-toolbox.git#5e6587e01cee9d93227e40f267f96efbbbd79161"
 dependencies = [
  "io_utils 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1997,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "vdj_ann"
 version = "0.1.0"
-source = "git+https://github.com/10XGenomics/rust-toolbox.git#eb863f69a3f979fa30ed4667e5f354a20845950c"
+source = "git+https://github.com/10XGenomics/rust-toolbox.git#5e6587e01cee9d93227e40f267f96efbbbd79161"
 dependencies = [
  "align_tools 0.1.0 (git+https://github.com/10XGenomics/rust-toolbox.git)",
  "amino 0.1.0 (git+https://github.com/10XGenomics/rust-toolbox.git)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "enclone"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "amino 0.1.0 (git+https://github.com/10XGenomics/rust-toolbox.git)",
  "ansi_escape 0.1.0 (git+https://github.com/10XGenomics/rust-toolbox.git)",

--- a/build_help
+++ b/build_help
@@ -1,7 +1,7 @@
 #!/bin/csh
 
-enclone HTML STABLE_DOC      > pages/auto/help.main.html
-enclone HTML STABLE_DOC help > pages/auto/help.setup.html
+target/debug/enclone HTML STABLE_DOC      > pages/auto/help.main.html
+target/debug/enclone HTML STABLE_DOC help > pages/auto/help.setup.html
 foreach x (quick how command glossary example1 example2 support input input_tech parseable plot filter special lvars cvars amino display indels color ideas faq developer all)
-    enclone help $x HTML STABLE_DOC > pages/auto/help.$x.html
+    target/debug/enclone help $x HTML STABLE_DOC > pages/auto/help.$x.html
 end

--- a/index.html
+++ b/index.html
@@ -512,5 +512,11 @@ enclone is beta software and thus a work in progress.  We are actively making ma
 be unable to respond promptly to your particular request.
 </p>
 
+<hr>
+
+<h2>Where am I?</h2>
+
+<p style="margin-top: 30px; font-family: DejaVuSansMono; font-size: 200%; color: blue">bit.ly/enclone</p>
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -516,7 +516,8 @@ be unable to respond promptly to your particular request.
 
 <h2>Where am I?</h2>
 
-<p style="margin-top: 30px; font-family: DejaVuSansMono; font-size: 200%; color: blue">bit.ly/enclone</p>
+<!-- dunno why negative left margin needed to line things up on left: -->
+<p style="margin-left: -1.5px; margin-top: 30px; font-family: DejaVuSansMono; font-size: 200%; color: blue">bit.ly/enclone</p>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/index.html
+++ b/index.html
@@ -158,8 +158,7 @@ or on a Mac
 <code>curl -L https://github.com/10XGenomics/enclone/releases/latest/download/enclone_macos --output enclone; chmod +x enclone</code></pre>
 
 <p>This gets you the absolute latest version of enclone.  You can repeat this step if you ever
-want to update.  At a later date, there will also be separately numbered releases that have passed
-a more extensive set of tests.</p>
+want to update.</p>
 <p>It is not necessary to compile enclone, unless you want to contribute
 to the enclone codebase.  
 Please see <b><a href="pages/compile.html">compilation</a></b>.</p>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title>bt.ly/enclone</title>
+<title>enclone (bt.ly/enclone)</title>
 <link rel="stylesheet" type="text/css" href="pages/enclone.css">
 </head>
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title>enclone</title>
+<title>bt.ly/enclone</title>
 <link rel="stylesheet" type="text/css" href="pages/enclone.css">
 </head>
 

--- a/pages/auto/clonotype_with_gex.html
+++ b/pages/auto/clonotype_with_gex.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title>enclone output</title>
+<title>enclone example with gex</title>
 <link href='https://10xgenomics.github.io/enclone/pages/enclone.css' rel='stylesheet' type='text/css'>
 </head>
 <body>

--- a/pages/auto/clonotype_with_gex.html
+++ b/pages/auto/clonotype_with_gex.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/clonotype_with_gex.html
+++ b/pages/auto/clonotype_with_gex.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title></title>
+<title>enclone output</title>
 <link href='https://10xgenomics.github.io/enclone/pages/enclone.css' rel='stylesheet' type='text/css'>
 </head>
 <body>

--- a/pages/auto/expanded.html
+++ b/pages/auto/expanded.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.all.html
+++ b/pages/auto/help.all.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.all.html
+++ b/pages/auto/help.all.html
@@ -482,7 +482,7 @@ support for the software, please email us at enclone@10xgenomics.com if you have
 questions or comments (see below).  If you prefer you may submit a GitHub issue.</span>
 
 <span style="color:#5833ff;">Please note that syntax and features in enclone will change over time.  See</span>
-<span style="color:#25bc24;">https://10xgenomics.github.io/enclone/pages/history.html</span> <span style="color:#5833ff;">for the history of what was changed</span>
+history page at <span style="color:#25bc24;">bit.ly/enclone</span> <span style="color:#5833ff;">for the history of what was changed</span>
 <span style="color:#5833ff;">and when.  We will try not to break</span> <span style="color:#5833ff;">things, but when we first introduce a feature, it may</span>
 <span style="color:#5833ff;">not be just right, and we may have to to perturb it later.</span>
 
@@ -536,7 +536,7 @@ enclone help plot
 <span style="font-weight:bold;">plotting clonotypes</span>
 
 enclone can create a "honeycomb" plot showing each clonotype as a cluster of dots, one per cell. 
-You can see an example at <span style="color:#25bc24;">https://10xgenomics.github.io/enclone/index.html#honeycomb</span>.
+You can see an example at <span style="color:#25bc24;">bit.ly/enclone</span>.
 
 enclone provides three ways to assign colors in such a plot.  We describe them in order of
 precedence, i.e. color data for the first will be used if provided, etc.
@@ -616,7 +616,7 @@ the same donor, and semicolons separate donors.  If semicolons are used, the val
 enclone uses the distinction between datasets, samples and donors in the following ways:
 1. If two datasets come from the same sample, then enclone can filter to remove certain artifacts,
 unless you specify the option <span style="font-weight:bold;">NCROSS</span>.
-See also <span style="color:#25bc24;">https://10xgenomics.github.io/enclone/pages/auto/expanded.html</span>.
+See also illusory clonotypes page at <span style="color:#25bc24;">bit.ly/enclone</span>.
 2. If two cells came from different donors, then enclone will not put them in the same clonotype,
 unless you specify the option <span style="font-weight:bold;">MIX_DONORS</span>.
 More information may be found at `enclone help special`.  In addition, this is enclone's way of
@@ -1559,7 +1559,7 @@ enclone help developer
 <span style="font-weight:bold;">a few options for developers</span>
 
 For instructions on how to compile, please see
-<span style="color:#25bc24;">https://10xgenomics.github.io/enclone/pages/compile.html</span>.
+<span style="color:#25bc24;">bit.ly/enclone</span>.
 
 ┌───────────┬──────────────────────────────────────────────────────────────────────────────────┐
 │COMP       │  report computational performance stats; use this with NOPRINT if you            │

--- a/pages/auto/help.all.html
+++ b/pages/auto/help.all.html
@@ -616,7 +616,7 @@ the same donor, and semicolons separate donors.  If semicolons are used, the val
 enclone uses the distinction between datasets, samples and donors in the following ways:
 1. If two datasets come from the same sample, then enclone can filter to remove certain artifacts,
 unless you specify the option <span style="font-weight:bold;">NCROSS</span>.
-See also illusory clonotypes page at <span style="color:#25bc24;">bit.ly/enclone</span>.
+See also illusory clonotype expansion page at <span style="color:#25bc24;">bit.ly/enclone</span>.
 2. If two cells came from different donors, then enclone will not put them in the same clonotype,
 unless you specify the option <span style="font-weight:bold;">MIX_DONORS</span>.
 More information may be found at `enclone help special`.  In addition, this is enclone's way of

--- a/pages/auto/help.all.html
+++ b/pages/auto/help.all.html
@@ -1420,7 +1420,8 @@ may help, or even
 
 Yes, there are choices:
 <span style="font-weight:bold;">A</span>. On a Mac, you can screenshot from a terminal window.
-<span style="font-weight:bold;">B</span>. Add the argument <span style="font-weight:bold;">HTML</span> to the enclone command line.  Then the output will be presented as html.
+<span style="font-weight:bold;">B</span>. Add the argument <span style="font-weight:bold;">HTML</span> to the enclone command line.  Then the output will be presented as html,
+with title "enclone output".  If you want to set the title, use <span style="font-weight:bold;">HTML="..."</span>.
 <span style="font-weight:bold;">C</span>. You can then convert the html to pdf.  The best way on a Mac is to open Safari, which is the
 best browser for this particular purpose, select the file where you've saved the html, and then
 export as pdf.  Do not convert to pdf via printing, which produces a less readable file, and also

--- a/pages/auto/help.amino.html
+++ b/pages/auto/help.amino.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.color.html
+++ b/pages/auto/help.color.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.command.html
+++ b/pages/auto/help.command.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.cvars.html
+++ b/pages/auto/help.cvars.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.developer.html
+++ b/pages/auto/help.developer.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.developer.html
+++ b/pages/auto/help.developer.html
@@ -12,7 +12,7 @@
 <span style="font-weight:bold;">a few options for developers</span>
 
 For instructions on how to compile, please see
-<span style="color:#25bc24;">https://10xgenomics.github.io/enclone/pages/compile.html</span>.
+<span style="color:#25bc24;">bit.ly/enclone</span>.
 
 ┌───────────┬──────────────────────────────────────────────────────────────────────────────────┐
 │COMP       │  report computational performance stats; use this with NOPRINT if you            │

--- a/pages/auto/help.display.html
+++ b/pages/auto/help.display.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.example1.html
+++ b/pages/auto/help.example1.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.example2.html
+++ b/pages/auto/help.example2.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.faq.html
+++ b/pages/auto/help.faq.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.faq.html
+++ b/pages/auto/help.faq.html
@@ -40,7 +40,8 @@ may help, or even
 
 Yes, there are choices:
 <span style="font-weight:bold;">A</span>. On a Mac, you can screenshot from a terminal window.
-<span style="font-weight:bold;">B</span>. Add the argument <span style="font-weight:bold;">HTML</span> to the enclone command line.  Then the output will be presented as html.
+<span style="font-weight:bold;">B</span>. Add the argument <span style="font-weight:bold;">HTML</span> to the enclone command line.  Then the output will be presented as html,
+with title "enclone output".  If you want to set the title, use <span style="font-weight:bold;">HTML="..."</span>.
 <span style="font-weight:bold;">C</span>. You can then convert the html to pdf.  The best way on a Mac is to open Safari, which is the
 best browser for this particular purpose, select the file where you've saved the html, and then
 export as pdf.  Do not convert to pdf via printing, which produces a less readable file, and also

--- a/pages/auto/help.filter.html
+++ b/pages/auto/help.filter.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.glossary.html
+++ b/pages/auto/help.glossary.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.how.html
+++ b/pages/auto/help.how.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.ideas.html
+++ b/pages/auto/help.ideas.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.indels.html
+++ b/pages/auto/help.indels.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.input.html
+++ b/pages/auto/help.input.html
@@ -49,7 +49,7 @@ the same donor, and semicolons separate donors.  If semicolons are used, the val
 enclone uses the distinction between datasets, samples and donors in the following ways:
 1. If two datasets come from the same sample, then enclone can filter to remove certain artifacts,
 unless you specify the option <span style="font-weight:bold;">NCROSS</span>.
-See also <span style="color:#25bc24;">https://10xgenomics.github.io/enclone/pages/auto/expanded.html</span>.
+See also illusory clonotypes page at <span style="color:#25bc24;">bit.ly/enclone</span>.
 2. If two cells came from different donors, then enclone will not put them in the same clonotype,
 unless you specify the option <span style="font-weight:bold;">MIX_DONORS</span>.
 More information may be found at `enclone help special`.  In addition, this is enclone's way of

--- a/pages/auto/help.input.html
+++ b/pages/auto/help.input.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.input.html
+++ b/pages/auto/help.input.html
@@ -49,7 +49,7 @@ the same donor, and semicolons separate donors.  If semicolons are used, the val
 enclone uses the distinction between datasets, samples and donors in the following ways:
 1. If two datasets come from the same sample, then enclone can filter to remove certain artifacts,
 unless you specify the option <span style="font-weight:bold;">NCROSS</span>.
-See also illusory clonotypes page at <span style="color:#25bc24;">bit.ly/enclone</span>.
+See also illusory clonotype expansion page at <span style="color:#25bc24;">bit.ly/enclone</span>.
 2. If two cells came from different donors, then enclone will not put them in the same clonotype,
 unless you specify the option <span style="font-weight:bold;">MIX_DONORS</span>.
 More information may be found at `enclone help special`.  In addition, this is enclone's way of

--- a/pages/auto/help.input_tech.html
+++ b/pages/auto/help.input_tech.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.lvars.html
+++ b/pages/auto/help.lvars.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.main.html
+++ b/pages/auto/help.main.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.parseable.html
+++ b/pages/auto/help.parseable.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.plot.html
+++ b/pages/auto/help.plot.html
@@ -12,7 +12,7 @@
 <span style="font-weight:bold;">plotting clonotypes</span>
 
 enclone can create a "honeycomb" plot showing each clonotype as a cluster of dots, one per cell. 
-You can see an example at <span style="color:#25bc24;">https://10xgenomics.github.io/enclone/index.html#honeycomb</span>.
+You can see an example at <span style="color:#25bc24;">bit.ly/enclone</span>.
 
 enclone provides three ways to assign colors in such a plot.  We describe them in order of
 precedence, i.e. color data for the first will be used if provided, etc.

--- a/pages/auto/help.plot.html
+++ b/pages/auto/help.plot.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.quick.html
+++ b/pages/auto/help.quick.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.setup.html
+++ b/pages/auto/help.setup.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.special.html
+++ b/pages/auto/help.special.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.support.html
+++ b/pages/auto/help.support.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/help.support.html
+++ b/pages/auto/help.support.html
@@ -14,7 +14,7 @@ support for the software, please email us at enclone@10xgenomics.com if you have
 questions or comments (see below).  If you prefer you may submit a GitHub issue.</span>
 
 <span style="color:#5833ff;">Please note that syntax and features in enclone will change over time.  See</span>
-<span style="color:#25bc24;">https://10xgenomics.github.io/enclone/pages/history.html</span> <span style="color:#5833ff;">for the history of what was changed</span>
+history page at <span style="color:#25bc24;">bit.ly/enclone</span> <span style="color:#5833ff;">for the history of what was changed</span>
 <span style="color:#5833ff;">and when.  We will try not to break</span> <span style="color:#5833ff;">things, but when we first introduce a feature, it may</span>
 <span style="color:#5833ff;">not be just right, and we may have to to perturb it later.</span>
 

--- a/pages/auto/illusory1.html
+++ b/pages/auto/illusory1.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/illusory1.html
+++ b/pages/auto/illusory1.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title></title>
+<title>enclone output</title>
 <link href='https://10xgenomics.github.io/enclone/pages/enclone.css' rel='stylesheet' type='text/css'>
 </head>
 <body>

--- a/pages/auto/illusory1.html
+++ b/pages/auto/illusory1.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title>enclone output</title>
+<title>illusory clonotype expansion 1</title>
 <link href='https://10xgenomics.github.io/enclone/pages/enclone.css' rel='stylesheet' type='text/css'>
 </head>
 <body>

--- a/pages/auto/illusory2.html
+++ b/pages/auto/illusory2.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/illusory2.html
+++ b/pages/auto/illusory2.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title></title>
+<title>enclone output</title>
 <link href='https://10xgenomics.github.io/enclone/pages/enclone.css' rel='stylesheet' type='text/css'>
 </head>
 <body>

--- a/pages/auto/illusory2.html
+++ b/pages/auto/illusory2.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title>enclone output</title>
+<title>illusory clonotype expansion 2</title>
 <link href='https://10xgenomics.github.io/enclone/pages/enclone.css' rel='stylesheet' type='text/css'>
 </head>
 <body>

--- a/pages/auto/illusory3.html
+++ b/pages/auto/illusory3.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/illusory3.html
+++ b/pages/auto/illusory3.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title></title>
+<title>enclone output</title>
 <link href='https://10xgenomics.github.io/enclone/pages/enclone.css' rel='stylesheet' type='text/css'>
 </head>
 <body>

--- a/pages/auto/illusory3.html
+++ b/pages/auto/illusory3.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title>enclone output</title>
+<title>illusory clonotype expansion 3</title>
 <link href='https://10xgenomics.github.io/enclone/pages/enclone.css' rel='stylesheet' type='text/css'>
 </head>
 <body>

--- a/pages/auto/illusory4.html
+++ b/pages/auto/illusory4.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/illusory4.html
+++ b/pages/auto/illusory4.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title>enclone output</title>
+<title>illusory clonotype expansion 4</title>
 <link href='https://10xgenomics.github.io/enclone/pages/enclone.css' rel='stylesheet' type='text/css'>
 </head>
 <body>

--- a/pages/auto/illusory4.html
+++ b/pages/auto/illusory4.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title></title>
+<title>enclone output</title>
 <link href='https://10xgenomics.github.io/enclone/pages/enclone.css' rel='stylesheet' type='text/css'>
 </head>
 <body>

--- a/pages/auto/illusory5.html
+++ b/pages/auto/illusory5.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/auto/illusory5.html
+++ b/pages/auto/illusory5.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title></title>
+<title>enclone output</title>
 <link href='https://10xgenomics.github.io/enclone/pages/enclone.css' rel='stylesheet' type='text/css'>
 </head>
 <body>

--- a/pages/auto/illusory5.html
+++ b/pages/auto/illusory5.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title>enclone output</title>
+<title>illusory clonotype expansion 5</title>
 <link href='https://10xgenomics.github.io/enclone/pages/enclone.css' rel='stylesheet' type='text/css'>
 </head>
 <body>

--- a/pages/compile.html
+++ b/pages/compile.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/expanded.html.src
+++ b/pages/expanded.html.src
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/fetching_test_datasets.html
+++ b/pages/fetching_test_datasets.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/history.html
+++ b/pages/history.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/index.html.src
+++ b/pages/index.html.src
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/pages/index.html.src
+++ b/pages/index.html.src
@@ -478,7 +478,8 @@ be unable to respond promptly to your particular request.
 
 <h2>Where am I?</h2>
 
-<p style="margin-top: 30px; font-family: DejaVuSansMono; font-size: 200%; color: blue">bit.ly/enclone</p>
+<!-- dunno why negative left margin needed to line things up on left: -->
+<p style="margin-left: -1.5px; margin-top: 30px; font-family: DejaVuSansMono; font-size: 200%; color: blue">bit.ly/enclone</p>
 
 </body>
 </html>

--- a/pages/index.html.src
+++ b/pages/index.html.src
@@ -474,5 +474,11 @@ enclone is beta software and thus a work in progress.  We are actively making ma
 be unable to respond promptly to your particular request.
 </p>
 
+<hr>
+
+<h2>Where am I?</h2>
+
+<p style="margin-top: 30px; font-family: DejaVuSansMono; font-size: 200%; color: blue">bit.ly/enclone</p>
+
 </body>
 </html>

--- a/pages/index.html.src
+++ b/pages/index.html.src
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title>bt.ly/enclone</title>
+<title>enclone (bt.ly/enclone)</title>
 <link rel="stylesheet" type="text/css" href="pages/enclone.css">
 </head>
 

--- a/pages/index.html.src
+++ b/pages/index.html.src
@@ -141,8 +141,7 @@ or on a Mac
 <code>curl -L https://github.com/10XGenomics/enclone/releases/latest/download/enclone_macos --output enclone; chmod +x enclone</code></pre>
 
 <p>This gets you the absolute latest version of enclone.  You can repeat this step if you ever
-want to update.  At a later date, there will also be separately numbered releases that have passed
-a more extensive set of tests.</p>
+want to update.</p>
 <p>It is not necessary to compile enclone, unless you want to contribute
 to the enclone codebase.  
 Please see <b><a href="pages/compile.html">compilation</a></b>.</p>

--- a/pages/index.html.src
+++ b/pages/index.html.src
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title>enclone</title>
+<title>bt.ly/enclone</title>
 <link rel="stylesheet" type="text/css" href="pages/enclone.css">
 </head>
 

--- a/src/bin/build_html.rs
+++ b/src/bin/build_html.rs
@@ -3,6 +3,7 @@
 // Build html files by generating and inserting other html files.
 
 use enclone::html::insert_html;
+use enclone::misc3::parse_bsv;
 use enclone::testlist::SITE_EXAMPLES;
 use pretty_trace::*;
 use std::fs::File;
@@ -15,11 +16,10 @@ fn main() {
         let example_name = SITE_EXAMPLES[i].0;
         let test = SITE_EXAMPLES[i].1;
         let out_file = format!("pages/auto/{}.html", example_name);
-        let args = test.split(' ').collect::<Vec<&str>>();
+        let args = parse_bsv(&test);
         let outputs = File::create(&out_file).unwrap();
         Command::new("target/debug/enclone")
             .args(&args)
-            .arg("HTML")
             .stdout(Stdio::from(outputs))
             .spawn()
             .unwrap()

--- a/src/defs.rs
+++ b/src/defs.rs
@@ -363,6 +363,7 @@ pub struct GeneralOpt {
     pub force_h5: bool,
     pub full_counts: bool,
     pub html: bool,
+    pub html_title: String,
     pub svg: bool,
     pub stable_doc: bool,
     pub imgt: bool,

--- a/src/group.rs
+++ b/src/group.rs
@@ -681,7 +681,7 @@ pub fn group_and_print_clonotypes(
         let s = convert_text_with_ansi_escapes_to_html(
             strme(&logx),
             "", // source
-            "", // title
+            &ctl.gen_opt.html_title,
             "<link href='https://10xgenomics.github.io/enclone/pages/enclone.css' \
              rel='stylesheet' type='text/css'>",
             "DejaVuSansMono",

--- a/src/help2.rs
+++ b/src/help2.rs
@@ -145,7 +145,7 @@ pub fn help2(args: &Vec<String>, ctl: &EncloneControl, h: &mut HelpDesk) {
              enclone@10xgenomics.com if you have problems, questions or comments (see below).  \
              If you prefer you may submit a GitHub issue.}\n\n\
              \\blue{Please note that syntax and features in enclone will change over time.  See}\n\
-             \\green{https://10xgenomics.github.io/enclone/pages/history.html} \
+             history page at \\green{bit.ly/enclone} \
              \\blue{for the history of what was changed}\n\
              \\blue{and when.  We will try not to break} \
              \\blue{things, but when we first introduce a feature, it may}\n\
@@ -214,7 +214,7 @@ pub fn help2(args: &Vec<String>, ctl: &EncloneControl, h: &mut HelpDesk) {
         h.print(
             "enclone can create a \"honeycomb\" plot showing each clonotype as a cluster of \
              dots, one per cell.  You can see an example at \
-             \\green{https://10xgenomics.github.io/enclone/index.html#honeycomb}.\n\n\
+             \\green{bit.ly/enclone}.\n\n\
              \
              enclone provides three ways to assign colors in such a plot.  We describe them in \
              order of precedence, i.e. color data for the first will be used if provided, etc.\n\n\
@@ -314,8 +314,7 @@ pub fn help2(args: &Vec<String>, ctl: &EncloneControl, h: &mut HelpDesk) {
              ways:\n\
              1. If two datasets come from the same sample, then enclone can filter to remove \
              certain artifacts, unless you specify the option \\bold{NCROSS}.\n\
-             See also \\green{\
-             https://10xgenomics.github.io/enclone/pages/auto/expanded.html}.\n\
+             See also illusory clonotypes page at \\green{bit.ly/enclone}.\n\
              2. If two cells came from different donors, then enclone will not put them in the \
              same clonotype, unless you specify the option \\bold{MIX_DONORS}.\n\
              More information may be found at `enclone help special`.  In addition, this is \

--- a/src/help2.rs
+++ b/src/help2.rs
@@ -314,7 +314,7 @@ pub fn help2(args: &Vec<String>, ctl: &EncloneControl, h: &mut HelpDesk) {
              ways:\n\
              1. If two datasets come from the same sample, then enclone can filter to remove \
              certain artifacts, unless you specify the option \\bold{NCROSS}.\n\
-             See also illusory clonotypes page at \\green{bit.ly/enclone}.\n\
+             See also illusory clonotype expansion page at \\green{bit.ly/enclone}.\n\
              2. If two cells came from different donors, then enclone will not put them in the \
              same clonotype, unless you specify the option \\bold{MIX_DONORS}.\n\
              More information may be found at `enclone help special`.  In addition, this is \

--- a/src/help5.rs
+++ b/src/help5.rs
@@ -178,7 +178,8 @@ pub fn help5(args: &Vec<String>, ctl: &EncloneControl, h: &mut HelpDesk) {
             "Yes, there are choices:\n\
              \\bold{A}. On a Mac, you can screenshot from a terminal window.\n\
              \\bold{B}. Add the argument \\bold{HTML} to the enclone command line.  Then the \
-             output will be presented as html.\n\
+             output will be presented as html, with title \"enclone output\".  If you want to \
+             set the title, use \\bold{HTML=\"...\"}.\n\
              \\bold{C}. You can then convert the html to pdf.  The best way on a Mac is to open \
              Safari, which is the best browser for this particular purpose, \
              select the file where you've saved the html, and then export as pdf.  Do not convert \

--- a/src/help5.rs
+++ b/src/help5.rs
@@ -364,7 +364,7 @@ pub fn help5(args: &Vec<String>, ctl: &EncloneControl, h: &mut HelpDesk) {
         h.print("\n\\bold{a few options for developers}\n\n");
         h.print(
             "For instructions on how to compile, please see\n\
-             \\green{https://10xgenomics.github.io/enclone/pages/compile.html}.\n\n",
+             \\green{bit.ly/enclone}.\n\n",
         );
         h.doc(
             "COMP",

--- a/src/misc3.rs
+++ b/src/misc3.rs
@@ -13,6 +13,44 @@ use vector_utils::*;
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 
+// Parse a line, breaking at blanks, but not if they're in quotes.  And strip the quotes.
+// Ridiculously similar to parse_csv, probably should refactor.
+
+pub fn parse_bsv(x: &str) -> Vec<String> {
+    let mut args = Vec::<String>::new();
+    let mut w = Vec::<char>::new();
+    for c in x.chars() {
+        w.push(c);
+    }
+    let (mut quotes, mut i) = (0, 0);
+    while i < w.len() {
+        let mut j = i;
+        while j < w.len() {
+            if quotes % 2 == 0 && w[j] == ' ' {
+                break;
+            }
+            if w[j] == '"' {
+                quotes += 1;
+            }
+            j += 1;
+        }
+        let (mut start, mut stop) = (i, j);
+        if stop - start >= 2 && w[start] == '"' && w[stop - 1] == '"' {
+            start += 1;
+            stop -= 1;
+        }
+        let mut s = String::new();
+        for m in start..stop {
+            s.push(w[m]);
+        }
+        args.push(s);
+        i = j + 1;
+    }
+    args
+}
+
+// ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+
 pub fn sort_tig_bc(ctl: &EncloneControl, tig_bc: &mut Vec<Vec<TigData>>, refdata: &RefData) {
     tig_bc.sort_by(|x, y| -> Ordering {
         for i in 0..x.len() {

--- a/src/proc_args.rs
+++ b/src/proc_args.rs
@@ -218,7 +218,7 @@ pub fn proc_args(mut ctl: &mut EncloneControl, args: &Vec<String>) {
             ctl.gen_opt.ncell = true;
         } else if arg == "LEGEND" {
             ctl.gen_opt.use_legend = true;
-        } else if arg == "HTML" {
+        } else if arg == "HTML" || arg.starts_with("HTML=") {
         } else if arg == "SVG" {
         } else if arg.starts_with("LEGEND=") {
             let x = parse_csv(&arg.after("LEGEND="));

--- a/src/proc_args2.rs
+++ b/src/proc_args2.rs
@@ -114,6 +114,15 @@ pub fn setup(mut ctl: &mut EncloneControl, args: &Vec<String>) {
                 to_delete[i] = true;
             } else if args[i] == "HTML" {
                 ctl.gen_opt.html = true;
+                ctl.gen_opt.html_title = "enclone output".to_string();
+                to_delete[i] = true;
+            } else if args[i].starts_with("HTML=") {
+                ctl.gen_opt.html = true;
+                let mut title = args[i].after("HTML=").to_string();
+                if title.starts_with("\"") && title.ends_with("\"") {
+                    title = title.between("\"", "\"").to_string();
+                }
+                ctl.gen_opt.html_title = title;
                 to_delete[i] = true;
             } else if args[i] == "SVG" {
                 ctl.gen_opt.svg = true;

--- a/src/testlist.rs
+++ b/src/testlist.rs
@@ -146,7 +146,7 @@ pub const TESTS: [&str; 71] = [
     r###"BCR=123085 GEX=123749 LVARSP=gex_mean,gex_Σ CDR3=CASRKSGNYIIYW NGEX H5"###,
     // 49. test HTML
     r###"BCR=85333 CDR3=CAAWDDSLNGWVF CHAINS=1 POUT=stdouth PCOLS=barcodes,n FASTA=stdout
-        FASTA_AA=stdout HTML"###,
+        FASTA_AA=stdout HTML=CAAWDDSLNGWVF"###,
     // 50. make sure this doesn't fail
     r###"NOPAGER EXPECT_OK"###,
     // 51. make sure this fails gracefully

--- a/src/testlist.rs
+++ b/src/testlist.rs
@@ -215,30 +215,36 @@ pub const SITE_EXAMPLES: [(&str, &str); 6] = [
     // 1.
     (
         "clonotype_with_gex",
-        "BCR=123085 CDR3=CQQRSNWPPSITF GEX=123749 LVARSP=gex,IGHV3-49_g,CD19_ab",
+        "BCR=123085 CDR3=CQQRSNWPPSITF GEX=123749 LVARSP=gex,IGHV3-49_g,CD19_ab \
+         HTML=\"enclone example with gex\"",
     ),
     // 2.
     (
         "illusory1",
-        "BCR=128037,128040 NCROSS CDR3=CARGGTTTYFISW NGROUP",
+        "BCR=128037,128040 NCROSS CDR3=CARGGTTTYFISW NGROUP \
+         HTML=\"illusory clonotype expansion 1\"",
     ),
     // 3.
-    ("illusory2", "BCR=128037,128040 CDR3=CARGGTTTYFISW NGROUP"),
+    (
+        "illusory2",
+        "BCR=128037,128040 CDR3=CARGGTTTYFISW NGROUP \
+      HTML=\"illusory clonotype expansion 2\"",
+    ),
     // 4.
     (
         "illusory3",
-        "BCR=128040 GEX=127801 CDR3=CARGGTTTYFISW NGROUP",
+        "BCR=128040 GEX=127801 CDR3=CARGGTTTYFISW NGROUP HTML=\"illusory clonotype expansion 3\"",
     ),
     // 5.
     (
         "illusory4",
         "BCR=128040 GEX=127801 CDR3=CARGGTTTYFISW PER_CELL LVARSP=gex,cred MIN_CHAINS_EXACT=2 \
-         NGROUP",
+         NGROUP HTML=\"illusory clonotype expansion 4\"",
     ),
     // 6.
     (
         "illusory5",
         "BCR=128040 GEX=127801 BC=128024_cells.csv CDR3=CARGGTTTYFISW PER_CELL \
-         LVARSP=gex,cred,T CHAINS_EXACT=2 NGROUP",
+         LVARSP=gex,cred,T CHAINS_EXACT=2 NGROUP HTML=\"illusory clonotype expansion 5\"",
     ),
 ];

--- a/test/inputs/outputs/enclone_test49_output
+++ b/test/inputs/outputs/enclone_test49_output
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/test/inputs/outputs/enclone_test49_output
+++ b/test/inputs/outputs/enclone_test49_output
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title></title>
+<title>CAAWDDSLNGWVF</title>
 <link href='https://10xgenomics.github.io/enclone/pages/enclone.css' rel='stylesheet' type='text/css'>
 </head>
 <body>

--- a/test/inputs/outputs/enclone_test59_output
+++ b/test/inputs/outputs/enclone_test59_output
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/test/inputs/outputs/enclone_test59_output
+++ b/test/inputs/outputs/enclone_test59_output
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title></title>
+<title>enclone output</title>
 <link href='https://10xgenomics.github.io/enclone/pages/enclone.css' rel='stylesheet' type='text/css'>
 </head>
 <body>

--- a/test/inputs/outputs/enclone_test60_output
+++ b/test/inputs/outputs/enclone_test60_output
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/test/inputs/outputs/enclone_test60_output
+++ b/test/inputs/outputs/enclone_test60_output
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title></title>
+<title>enclone output</title>
 <link href='https://10xgenomics.github.io/enclone/pages/enclone.css' rel='stylesheet' type='text/css'>
 </head>
 <body>

--- a/test/inputs/outputs/enclone_test63_output
+++ b/test/inputs/outputs/enclone_test63_output
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/test/inputs/outputs/enclone_test63_output
+++ b/test/inputs/outputs/enclone_test63_output
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title></title>
+<title>enclone output</title>
 <link href='https://10xgenomics.github.io/enclone/pages/enclone.css' rel='stylesheet' type='text/css'>
 </head>
 <body>

--- a/test/inputs/outputs/enclone_test64_output
+++ b/test/inputs/outputs/enclone_test64_output
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--  -->
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/test/inputs/outputs/enclone_test64_output
+++ b/test/inputs/outputs/enclone_test64_output
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
-<title></title>
+<title>enclone output</title>
 <link href='https://10xgenomics.github.io/enclone/pages/enclone.css' rel='stylesheet' type='text/css'>
 </head>
 <body>

--- a/tests/enclone_test.rs
+++ b/tests/enclone_test.rs
@@ -446,6 +446,10 @@ fn test_for_broken_links_and_spellcheck() {
     tested.insert("https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd".to_string());
     tested.insert("http://www.w3.org/1999/xhtml".to_string());
 
+    // Hardcode exception for funny svn URL.
+
+    tested.insert("https://github.com/10XGenomics/enclone/trunk".to_string());
+
     // Test each html.
 
     for x in htmls {

--- a/update_stable
+++ b/update_stable
@@ -1,6 +1,0 @@
-# Create stable copy of enclone, probably temporary.  Run ./local_view first.
-
-mkdir -p ~/enclone_stable
-cp target/debug/enclone ~/enclone_stable
-rm -rf ~/public_html/enclone_stable
-cp -pr ~/public_html/enclone ~/public_html/enclone_stable


### PR DESCRIPTION
- `HTML=...` now sets the title (default: enclone output)
- add titles for generated html clonotypes
- finds more links in html files to test
- fix some links, hardcode two slow exceptions
- nuke text about hardened releases
- help pages now point simply to `bit.ly/enclone` rather than specific pages
- title of landing page is now `bit.ly/enclone`
  **Do you like that way of getting `bit/ly/enclone` onto the page?**