### PR TITLE
Add include directives to enclone and enclone_main.

### DIFF
--- a/enclone/Cargo.toml
+++ b/enclone/Cargo.toml
@@ -11,6 +11,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
 edition = "2018"
 license = "LICENSE.txt"
 publish = false
+include = ["src/**/*", "!**/*_test.*", "!**/*_tests.*"]
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml
 # in the root of the enclone repo.

--- a/enclone_main/Cargo.toml
+++ b/enclone_main/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
 publish = false
+include = ["src/**/*"]
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml
 # in the root of the enclone repo.


### PR DESCRIPTION
These restrict the files that are included when a crate is published to
crates.io.  Published crates should not include files only needed for
tests. Unnecessary files contribute to build times, but more
seriously if there's enough of them then many containers used in for
example CI build systems simply don't have enough disk space to check
out the repo.

In enclone, the files omitted from the crate package are:
```
┌─────────────────────────────────────────────────
│ File                             │ Size (Byte) │
├─────────────────────────────────────────────────
│ src/bin/review_main_tests.rs     │        1051 │
│ src/bin/update_all_main_tests.rs │        1237 │
│ src/run_test.rs                  │       10749 │
└─────────────────────────────────────────────────
```

In enclone_main, it excludes the entire `test` directory, totalling a
whopping 839.1 MB - more than enough to prevent dependabot from being
able to operate on repos which depend on what should be a <100kB crate.

These changes were made with the
[`cargo-diet`](https://crates.io/crates/cargo-diet) tool.