### PR TITLE
Add Makefile

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/checkout@master
       - name: Check Rust formatting
         run: cargo fmt -- --check
-      - name: build-enclone
-        run: cargo build
-      - name: unit tests
-        run: cd enclone_main; cargo test --release --features basic -- --nocapture
+      - name: Build Enclone
+        run: make build
+      - name: Test Enclone
+        run: make test
 
   test-linux:
     # This job runs on Linux
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@master
       - name: Check Rust formatting
         run: cargo fmt -- --check
-      - name: build-enclone
-        run: cargo build
-      - name: unit tests
-        run: cd enclone_main; cargo test --release --features basic -- --nocapture
+      - name: Build Enclone
+        run: make build
+      - name: Test Enclone
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build:
 test: enclone_main/test/.gitignore
 	git -C $(<D) fetch --depth=1 origin tag v0.4.45
 	git -C $(<D) switch --detach FETCH_HEAD
-	cargo test
+	cargo test --features=basic
 
 # Download the test data.
 enclone_main/test/.gitignore:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+# Build Enclone.
+all: build
+
+.DELETE_ON_ERROR:
+.PHONY: all build test
+
+# Build Enclone.
+build:
+	cargo build
+
+# Test Enclone.
+test: enclone_main/test/.gitignore
+	git -C $(<D) fetch --depth=1 origin tag v0.4.45
+	git -C $(<D) switch --detach FETCH_HEAD
+	cargo test
+
+# Download the test data.
+enclone_main/test/.gitignore:
+	git clone --depth=1 https://github.com/10XGenomics/enclone-data $(@D)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build:
 
 # Test Enclone.
 test: enclone_main/test/.gitignore
-	git -C $(<D) fetch --depth=1 origin tag v0.4.45
+	git -C $(<D) fetch --depth=1 origin b0387a2540086c94b3737a09812f28835c1ca9ce
 	git -C $(<D) switch --detach FETCH_HEAD
 	cargo test --features=basic
 

--- a/build
+++ b/build
@@ -34,5 +34,5 @@ target/debug/merge_html
 
 # update dataset checksums
 
-git write-tree --prefix=enclone_main/test/inputs/version14/123085 > datasets_small_checksum
-git write-tree --prefix=enclone_main/test/inputs/version14 > datasets_medium_checksum
+git -C enclone_main/test write-tree --prefix=inputs/version14/123085 > datasets_small_checksum
+git -C enclone_main/test write-tree --prefix=inputs/version14 > datasets_medium_checksum

--- a/enclone_main/tests/enclone_test.rs
+++ b/enclone_main/tests/enclone_test.rs
@@ -341,7 +341,7 @@ fn test_curl_command() {
 #[test]
 fn test_datasets_sha256() {
     let sha_command1 = format!(
-        "git write-tree --prefix=enclone_main/test/inputs/version{}",
+        "git -C test write-tree --prefix=inputs/version{}",
         TEST_FILES_VERSION
     );
     let sha_command2 = "cat ../datasets_medium_checksum";
@@ -375,7 +375,7 @@ fn test_datasets_sha256() {
         std::process::exit(1);
     }
     let sha_command1 = format!(
-        "git write-tree --prefix=enclone_main/test/inputs/version{}/123085",
+        "git -C test write-tree --prefix=inputs/version{}/123085",
         TEST_FILES_VERSION
     );
     let sha_command2 = "cat ../datasets_small_checksum";
@@ -879,7 +879,7 @@ fn test_for_broken_links_and_spellcheck() {
 
     // Set up dictionary.
 
-    let dictionary0 = read_to_string("../enclone/src/english_wordlist").unwrap();
+    let dictionary0 = read_to_string("test/inputs/english_wordlist").unwrap();
     let dictionary0 = dictionary0.split('\n').collect::<Vec<&str>>();
     let mut dictionary = Vec::<String>::new();
     for w in dictionary0.iter() {


### PR DESCRIPTION
`make check` downloads the test data from https://github.com/10XGenomics/enclone-data before running `cargo test`. It's effectively a substitute for a Git submodule. We are avoiding using Git submodule here due to this open Cargo bug: `git submodules are not cached ` https://github.com/rust-lang/cargo/issues/7987

This PR is a draft, because it depends on adding the data to https://github.com/10XGenomics/enclone-data and remove the data from this repo.