### PR TITLE
improve column assignment in clonotype tables (WORK IN PROGRESS)

### DIFF
--- a/enclone/src/join.rs
+++ b/enclone/src/join.rs
@@ -35,6 +35,7 @@ pub fn join_exacts(
     exact_clonotypes: &Vec<ExactClonotype>,
     info: &Vec<CloneInfo>,
     mut join_info: &mut Vec<(usize, usize, bool, Vec<u8>)>,
+    raw_joins: &mut Vec<(i32, i32)>,
 ) -> EquivRel {
     // Run special option for joining by barcode identity.
 
@@ -458,5 +459,10 @@ pub fn join_exacts(
         }
     });
     ctl.perf_stats(&timer2, "in main part of join");
+    for l in 0..results.len() {
+        for j in 0..results[l].5.len() {
+            raw_joins.push((results[l].5[j].0 as i32, results[l].5[j].1 as i32));
+        }
+    }
     finish_join(&ctl, &info, &results, &mut join_info)
 }

--- a/enclone_main/src/main_enclone.rs
+++ b/enclone_main/src/main_enclone.rs
@@ -1516,10 +1516,11 @@ pub fn main_enclone(args: &Vec<String>) {
 
     sub_alts(&refdata, &ctl, &alt_refs, &mut info, &mut exact_clonotypes);
 
-    // Form equivalence relation on exact subclonotypes.
+    // Form equivalence relation on exact subclonotypes.  We also keep the raw joins, consisting
+    // of pairs of info indices, that were originally joined.
 
     let mut join_info = Vec::<(usize, usize, bool, Vec<u8>)>::new();
-    let mut _raw_joins = Vec::<(i32, i32)>::new();
+    let mut raw_joins = Vec::<(i32, i32)>::new();
     let mut eq: EquivRel = join_exacts(
         is_bcr,
         &refdata,
@@ -1527,11 +1528,11 @@ pub fn main_enclone(args: &Vec<String>) {
         &exact_clonotypes,
         &info,
         &mut join_info,
-        &mut _raw_joins,
+        &mut raw_joins,
     );
 
-    // If NWEAK_ONESIES is not specified, disintegrate certain onesie clonotypes into single
-    // cell clonotypes.  This requires editing of exact_clonotypes, info, eq and join_info.
+    // If NWEAK_ONESIES is not specified, disintegrate certain onesie clonotypes into single cell
+    // clonotypes.  This requires editing of exact_clonotypes, info, eq, join_info and raw_joins.
 
     let mut disintegrated = Vec::<bool>::new();
     if ctl.clono_filt_opt.weak_onesies {
@@ -1612,6 +1613,10 @@ pub fn main_enclone(args: &Vec<String>) {
         }
         eq = eq2;
     }
+
+    // After this point, info is not changed, so locking it.
+
+    let info = &info;
 
     // Lookup for heavy chain reuse (special purpose experimental option).
 

--- a/enclone_main/src/main_enclone.rs
+++ b/enclone_main/src/main_enclone.rs
@@ -2069,7 +2069,7 @@ pub fn main_enclone(args: &Vec<String>) {
                 exacts.push(od[j].1);
                 j = k;
             }
-            let mat = define_mat(&ctl, &exact_clonotypes, &cdr3s_len, &js, &od, &info);
+            let mat = define_mat(&ctl, &exact_clonotypes, &cdr3s_len, &js, &od, &info, &o);
             let nexacts = mat[0].len();
             let mut priority = Vec::<Vec<bool>>::new();
             for u in 0..nexacts {

--- a/enclone_main/src/main_enclone.rs
+++ b/enclone_main/src/main_enclone.rs
@@ -2069,7 +2069,7 @@ pub fn main_enclone(args: &Vec<String>) {
                 exacts.push(od[j].1);
                 j = k;
             }
-            let mat = define_mat(&ctl, &exact_clonotypes, &cdr3s_len, &js, &od, &info, &o);
+            let mat = define_mat(&ctl, &exact_clonotypes, &cdr3s_len, &js, &od, &info);
             let nexacts = mat[0].len();
             let mut priority = Vec::<Vec<bool>>::new();
             for u in 0..nexacts {

--- a/enclone_main/src/main_enclone.rs
+++ b/enclone_main/src/main_enclone.rs
@@ -1519,6 +1519,7 @@ pub fn main_enclone(args: &Vec<String>) {
     // Form equivalence relation on exact subclonotypes.
 
     let mut join_info = Vec::<(usize, usize, bool, Vec<u8>)>::new();
+    let mut _raw_joins = Vec::<(i32, i32)>::new();
     let mut eq: EquivRel = join_exacts(
         is_bcr,
         &refdata,
@@ -1526,6 +1527,7 @@ pub fn main_enclone(args: &Vec<String>) {
         &exact_clonotypes,
         &info,
         &mut join_info,
+        &mut _raw_joins,
     );
 
     // If NWEAK_ONESIES is not specified, disintegrate certain onesie clonotypes into single

--- a/enclone_main/src/main_enclone.rs
+++ b/enclone_main/src/main_enclone.rs
@@ -1631,7 +1631,7 @@ pub fn main_enclone(args: &Vec<String>) {
         raw_joins2[raw_joins[i].0 as usize].push(raw_joins[i].1 as usize);
         raw_joins2[raw_joins[i].1 as usize].push(raw_joins[i].0 as usize);
     }
-    let _raw_joins = raw_joins2;
+    let raw_joins = raw_joins2;
 
     // Lock info.
 
@@ -2095,7 +2095,15 @@ pub fn main_enclone(args: &Vec<String>) {
                 exacts.push(od[j].1);
                 j = k;
             }
-            let mat = define_mat(&ctl, &exact_clonotypes, &cdr3s_len, &js, &od, &info);
+            let mat = define_mat(
+                &ctl,
+                &exact_clonotypes,
+                &cdr3s_len,
+                &js,
+                &od,
+                &info,
+                &raw_joins,
+            );
             let nexacts = mat[0].len();
             let mut priority = Vec::<Vec<bool>>::new();
             for u in 0..nexacts {
@@ -2571,6 +2579,7 @@ pub fn main_enclone(args: &Vec<String>) {
         &exact_clonotypes,
         &info,
         &orbits,
+        &raw_joins,
         &gex_info,
         &vdj_cells,
         &d_readers,

--- a/enclone_main/src/main_enclone.rs
+++ b/enclone_main/src/main_enclone.rs
@@ -2073,6 +2073,7 @@ pub fn main_enclone(args: &Vec<String>) {
             let mut exacts = Vec::<usize>::new();
             let mut cdr3s_len = Vec::<Vec<(String, usize)>>::new();
             let mut js = Vec::<usize>::new();
+            let mut ks = Vec::<usize>::new();
             let mut j = 0;
             while j < od.len() {
                 let k = next_diff12_3(&od, j as i32) as usize;
@@ -2092,6 +2093,7 @@ pub fn main_enclone(args: &Vec<String>) {
                 unique_sort(&mut z_len);
                 cdr3s_len.push(z_len);
                 js.push(j);
+                ks.push(k);
                 exacts.push(od[j].1);
                 j = k;
             }
@@ -2100,6 +2102,7 @@ pub fn main_enclone(args: &Vec<String>) {
                 &exact_clonotypes,
                 &cdr3s_len,
                 &js,
+                &ks,
                 &od,
                 &info,
                 &raw_joins,

--- a/enclone_main/src/main_enclone.rs
+++ b/enclone_main/src/main_enclone.rs
@@ -1596,6 +1596,15 @@ pub fn main_enclone(args: &Vec<String>) {
             to_info2.push(x);
         }
         info = info2;
+        let mut raw_joins2 = Vec::<(i32, i32)>::new();
+        for i in 0..raw_joins.len() {
+            let (j1, j2) = (
+                &to_info2[raw_joins[i].0 as usize],
+                &to_info2[raw_joins[i].1 as usize],
+            );
+            raw_joins2.push((j1[0] as i32, j2[0] as i32));
+        }
+        raw_joins = raw_joins2;
         let mut reps = Vec::<i32>::new();
         eq.orbit_reps(&mut reps);
         let mut eq2 = EquivRel::new(info.len() as i32);
@@ -1614,9 +1623,10 @@ pub fn main_enclone(args: &Vec<String>) {
         eq = eq2;
     }
 
-    // After this point, info is not changed, so locking it.
+    // Lock some variables that can't change from now on.
 
     let info = &info;
+    let _raw_joins = &raw_joins;
 
     // Lookup for heavy chain reuse (special purpose experimental option).
 

--- a/enclone_main/src/main_enclone.rs
+++ b/enclone_main/src/main_enclone.rs
@@ -1623,10 +1623,19 @@ pub fn main_enclone(args: &Vec<String>) {
         eq = eq2;
     }
 
-    // Lock some variables that can't change from now on.
+    // Restructure raw joins.
+
+    raw_joins.sort();
+    let mut raw_joins2 = vec![Vec::<usize>::new(); info.len()];
+    for i in 0..raw_joins.len() {
+        raw_joins2[raw_joins[i].0 as usize].push(raw_joins[i].1 as usize);
+        raw_joins2[raw_joins[i].1 as usize].push(raw_joins[i].0 as usize);
+    }
+    let _raw_joins = raw_joins2;
+
+    // Lock info.
 
     let info = &info;
-    let _raw_joins = &raw_joins;
 
     // Lookup for heavy chain reuse (special purpose experimental option).
 

--- a/enclone_print/src/print_clonotypes.rs
+++ b/enclone_print/src/print_clonotypes.rs
@@ -42,6 +42,7 @@ pub fn print_clonotypes(
     exact_clonotypes: &Vec<ExactClonotype>,
     info: &Vec<CloneInfo>,
     orbits: &Vec<Vec<i32>>,
+    raw_joins: &Vec<Vec<usize>>,
     gex_info: &GexInfo,
     vdj_cells: &Vec<Vec<String>>,
     d_readers: &Vec<Option<hdf5::Reader>>,
@@ -268,7 +269,15 @@ pub fn print_clonotypes(
 
             // Sort exact subclonotypes.
 
-            let mat = define_mat(&ctl, &exact_clonotypes, &cdr3s_len, &js, &od, &info);
+            let mat = define_mat(
+                &ctl,
+                &exact_clonotypes,
+                &cdr3s_len,
+                &js,
+                &od,
+                &info,
+                &raw_joins,
+            );
             let mut priority = Vec::<(Vec<bool>, usize, usize)>::new();
             for u in 0..exacts.len() {
                 let mut typex = vec![false; mat.len()];
@@ -308,7 +317,15 @@ pub fn print_clonotypes(
             // reference sequence identifiers, CDR3 start positions, and the like.
 
             let nexacts = exacts.len();
-            let mat = define_mat(&ctl, &exact_clonotypes, &cdr3s_len, &js, &od, &info);
+            let mat = define_mat(
+                &ctl,
+                &exact_clonotypes,
+                &cdr3s_len,
+                &js,
+                &od,
+                &info,
+                &raw_joins,
+            );
             let cols = mat.len();
             let mut rsi = define_column_info(&ctl, &exacts, &exact_clonotypes, &mat, &refdata);
             rsi.mat = mat;

--- a/enclone_print/src/print_clonotypes.rs
+++ b/enclone_print/src/print_clonotypes.rs
@@ -268,7 +268,7 @@ pub fn print_clonotypes(
 
             // Sort exact subclonotypes.
 
-            let mat = define_mat(&ctl, &exact_clonotypes, &cdr3s_len, &js, &od, &info);
+            let mat = define_mat(&ctl, &exact_clonotypes, &cdr3s_len, &js, &od, &info, &o);
             let mut priority = Vec::<(Vec<bool>, usize, usize)>::new();
             for u in 0..exacts.len() {
                 let mut typex = vec![false; mat.len()];
@@ -308,7 +308,7 @@ pub fn print_clonotypes(
             // reference sequence identifiers, CDR3 start positions, and the like.
 
             let nexacts = exacts.len();
-            let mat = define_mat(&ctl, &exact_clonotypes, &cdr3s_len, &js, &od, &info);
+            let mat = define_mat(&ctl, &exact_clonotypes, &cdr3s_len, &js, &od, &info, &o);
             let cols = mat.len();
             let mut rsi = define_column_info(&ctl, &exacts, &exact_clonotypes, &mat, &refdata);
             rsi.mat = mat;

--- a/enclone_print/src/print_clonotypes.rs
+++ b/enclone_print/src/print_clonotypes.rs
@@ -268,7 +268,7 @@ pub fn print_clonotypes(
 
             // Sort exact subclonotypes.
 
-            let mat = define_mat(&ctl, &exact_clonotypes, &cdr3s_len, &js, &od, &info, &o);
+            let mat = define_mat(&ctl, &exact_clonotypes, &cdr3s_len, &js, &od, &info);
             let mut priority = Vec::<(Vec<bool>, usize, usize)>::new();
             for u in 0..exacts.len() {
                 let mut typex = vec![false; mat.len()];
@@ -308,7 +308,7 @@ pub fn print_clonotypes(
             // reference sequence identifiers, CDR3 start positions, and the like.
 
             let nexacts = exacts.len();
-            let mat = define_mat(&ctl, &exact_clonotypes, &cdr3s_len, &js, &od, &info, &o);
+            let mat = define_mat(&ctl, &exact_clonotypes, &cdr3s_len, &js, &od, &info);
             let cols = mat.len();
             let mut rsi = define_column_info(&ctl, &exacts, &exact_clonotypes, &mat, &refdata);
             rsi.mat = mat;

--- a/enclone_print/src/print_clonotypes.rs
+++ b/enclone_print/src/print_clonotypes.rs
@@ -213,6 +213,7 @@ pub fn print_clonotypes(
         let mut cdr3s = Vec::<Vec<String>>::new();
         let mut cdr3s_len = Vec::<Vec<(String, usize)>>::new();
         let mut js = Vec::<usize>::new();
+        let mut ks = Vec::<usize>::new();
         let mut j = 0;
         let loupe_clonotypes = &mut res.6;
         while j < od.len() {
@@ -243,6 +244,7 @@ pub fn print_clonotypes(
             cdr3s.push(z);
             cdr3s_len.push(z_len);
             js.push(j);
+            ks.push(k);
             let mut x = Vec::<usize>::new();
             for l in j..k {
                 x.push(l);
@@ -263,6 +265,7 @@ pub fn print_clonotypes(
                 erase_if(&mut cdr3s, &bads);
                 erase_if(&mut cdr3s_len, &bads);
                 erase_if(&mut js, &bads);
+                erase_if(&mut ks, &bads);
                 erase_if(&mut mults, &bads);
                 erase_if(&mut exacts, &bads);
             }
@@ -274,6 +277,7 @@ pub fn print_clonotypes(
                 &exact_clonotypes,
                 &cdr3s_len,
                 &js,
+                &ks,
                 &od,
                 &info,
                 &raw_joins,
@@ -305,11 +309,13 @@ pub fn print_clonotypes(
             cdr3s = permutation.apply_slice(&cdr3s[..]);
             cdr3s_len = permutation.apply_slice(&cdr3s_len[..]);
             js = permutation.apply_slice(&js[..]);
+            ks = permutation.apply_slice(&ks[..]);
             exacts.reverse();
             mults.reverse();
             cdr3s.reverse();
             cdr3s_len.reverse();
             js.reverse();
+            ks.reverse();
 
             // Define a matrix mat[col][ex] which is the column of the exact subclonotype
             // corresponding to the given column col of the clonotype, which may or may not be
@@ -322,6 +328,7 @@ pub fn print_clonotypes(
                 &exact_clonotypes,
                 &cdr3s_len,
                 &js,
+                &ks,
                 &od,
                 &info,
                 &raw_joins,

--- a/enclone_print/src/print_utils4.rs
+++ b/enclone_print/src/print_utils4.rs
@@ -22,6 +22,7 @@ pub fn define_mat(
     exact_clonotypes: &Vec<ExactClonotype>,
     cdr3s: &Vec<Vec<(String, usize)>>,
     js: &Vec<usize>,
+    ks: &Vec<usize>,
     od: &Vec<(Vec<usize>, usize, i32)>,
     info: &Vec<CloneInfo>,
     raw_joins: &Vec<Vec<usize>>,
@@ -51,12 +52,7 @@ pub fn define_mat(
                 &(cdr3s[u][k].0.as_bytes().to_vec(), cdr3s[u][k].1),
             );
             let j1 = js[u];
-            let j2;
-            if u + 1 < js.len() {
-                j2 = js[u + 1];
-            } else {
-                j2 = od.len();
-            }
+            let j2 = ks[u];
             for kx in j1..j2 {
                 let mut index = None;
                 let z = &info[od[kx].2 as usize];

--- a/enclone_print/src/print_utils4.rs
+++ b/enclone_print/src/print_utils4.rs
@@ -81,6 +81,11 @@ pub fn define_mat(
             let (x1, x2) = (&all_cdr3s[m1].0, &all_cdr3s[m2].0);
             let (y1, y2) = (all_cdr3s[m1].1, all_cdr3s[m2].1);
 
+            if x1 == x2 && y1 == y2 {
+                ec.join(m1 as i32, m2 as i32);
+                continue;
+            }
+
             let (r1, r2) = (&info_locs[m1], &info_locs[m2]);
             'r1r2: for j1 in r1.iter() {
                 for j2 in r2.iter() {

--- a/enclone_print/src/print_utils4.rs
+++ b/enclone_print/src/print_utils4.rs
@@ -24,6 +24,7 @@ pub fn define_mat(
     js: &Vec<usize>,
     od: &Vec<(Vec<usize>, usize, i32)>,
     info: &Vec<CloneInfo>,
+    _o: &Vec<i32>,
 ) -> Vec<Vec<Option<usize>>> {
     // Form the flattened list of all CDR3_AAs.
 

--- a/enclone_print/src/print_utils4.rs
+++ b/enclone_print/src/print_utils4.rs
@@ -15,7 +15,7 @@ use vector_utils::*;
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 
 // Note confusing notation.  The object cdr3 contains pairs (String,usize) consisting of
-// the cdr3_aa and the length of seq_del.
+// chain_type:cdr3_aa and the length of seq_del.
 
 pub fn define_mat(
     ctl: &EncloneControl,

--- a/enclone_print/src/print_utils4.rs
+++ b/enclone_print/src/print_utils4.rs
@@ -24,6 +24,7 @@ pub fn define_mat(
     js: &Vec<usize>,
     od: &Vec<(Vec<usize>, usize, i32)>,
     info: &Vec<CloneInfo>,
+    _raw_joins: &Vec<Vec<usize>>,
 ) -> Vec<Vec<Option<usize>>> {
     // Form the flattened list of all CDR3_AAs.
 

--- a/enclone_print/src/print_utils4.rs
+++ b/enclone_print/src/print_utils4.rs
@@ -24,7 +24,7 @@ pub fn define_mat(
     js: &Vec<usize>,
     od: &Vec<(Vec<usize>, usize, i32)>,
     info: &Vec<CloneInfo>,
-    _raw_joins: &Vec<Vec<usize>>,
+    raw_joins: &Vec<Vec<usize>>,
 ) -> Vec<Vec<Option<usize>>> {
     // Form the flattened list of all CDR3_AAs.
 
@@ -36,9 +36,44 @@ pub fn define_mat(
         }
     }
 
-    // Sort the CDR3s.
+    // Unique sort the CDR3s.
 
     unique_sort(&mut all_cdr3s);
+
+    // Find the info entries corresponding to each entry in all_cdr3s.
+    // An entry in info_locs is (index in info, index in that info entry).
+
+    let mut info_locs = vec![Vec::<(usize, usize)>::new(); all_cdr3s.len()];
+    for u in 0..nexacts {
+        for k in 0..cdr3s[u].len() {
+            let p = bin_position(
+                &all_cdr3s,
+                &(cdr3s[u][k].0.as_bytes().to_vec(), cdr3s[u][k].1),
+            );
+            let j1 = js[u];
+            let j2;
+            if u + 1 < js.len() {
+                j2 = js[u + 1];
+            } else {
+                j2 = od.len();
+            }
+            for kx in j1..j2 {
+                let mut index = None;
+                let z = &info[od[kx].2 as usize];
+                for l in 0..z.cdr3_aa.len() {
+                    if z.cdr3_aa[l] == cdr3s[u][k].0.after(":") {
+                        index = Some(l);
+                    }
+                }
+                if index.is_some() {
+                    info_locs[p as usize].push((od[kx].2 as usize, index.unwrap()));
+                }
+            }
+        }
+    }
+    for i in 0..info_locs.len() {
+        unique_sort(&mut info_locs[i]);
+    }
 
     // Form an equivalence relation on the CDR3_AAs, requiring that they are "close enough":
     // 1. They have the same length and differ at no more than 5 positions.
@@ -49,6 +84,36 @@ pub fn define_mat(
         for m2 in m1 + 1..all_cdr3s.len() {
             let (x1, x2) = (&all_cdr3s[m1].0, &all_cdr3s[m2].0);
             let (y1, y2) = (all_cdr3s[m1].1, all_cdr3s[m2].1);
+
+            let (r1, r2) = (&info_locs[m1], &info_locs[m2]);
+            'r1r2: for j1 in r1.iter() {
+                for j2 in r2.iter() {
+                    let j1 = *j1;
+                    let j2 = *j2;
+                    // if strme(&x1).before(":") == strme(&x2).before(":") {
+                    if info[j1.0].cdr3_aa[j1.1] == strme(&x1).after(":")
+                        && info[j2.0].cdr3_aa[j2.1] == strme(&x2).after(":")
+                        && j1.1 == j2.1
+                    {
+                        if bin_member(&raw_joins[j1.0], &j2.0) {
+                            /*
+                            // XXX:
+                            let z1 = format!("{}:{}", info[j1.0].cdr3_aa[0], info[j1.0].cdr3_aa[1]);
+                            let z2 = format!("{}:{}", info[j2.0].cdr3_aa[0], info[j2.0].cdr3_aa[1]);
+                            eprintln!(
+                            "joining {} to {}, lens = {} and {}, j = {}.{} and {}.{}, info = {} and {}",
+                                strme(&x1),
+                                strme(&x2), r1.len(), r2.len(), j1.0, j1.1, j2.0, j2.1, z1, z2);
+                            */
+
+                            ec.join(m1 as i32, m2 as i32);
+                            break 'r1r2;
+                        }
+                    }
+                }
+            }
+
+            /*
             if x1.len() == x2.len() && y1 == y2 {
                 let mut diffs = 0;
                 for u in 0..x1.len() {
@@ -92,6 +157,7 @@ pub fn define_mat(
                     }
                 }
             }
+            */
         }
     }
 

--- a/enclone_print/src/print_utils4.rs
+++ b/enclone_print/src/print_utils4.rs
@@ -24,7 +24,6 @@ pub fn define_mat(
     js: &Vec<usize>,
     od: &Vec<(Vec<usize>, usize, i32)>,
     info: &Vec<CloneInfo>,
-    _o: &Vec<i32>,
 ) -> Vec<Vec<Option<usize>>> {
     // Form the flattened list of all CDR3_AAs.
 

--- a/enclone_print/src/print_utils5.rs
+++ b/enclone_print/src/print_utils5.rs
@@ -350,4 +350,29 @@ pub fn delete_weaks(
             }
         }
     }
+
+    // Remove onesies that do not have an exact match.
+
+    if cols > 1 {
+        for u1 in 0..nexacts {
+            let ex1 = &exact_clonotypes[exacts[u1]];
+            if ex1.share.len() == 1 && !bads[u1] {
+                let mut perf = false;
+                'u2: for u2 in 0..nexacts {
+                    let ex2 = &exact_clonotypes[exacts[u2]];
+                    if ex2.share.len() > 1 && !bads[u2] {
+                        for i in 0..ex2.share.len() {
+                            if ex1.share[0].seq == ex2.share[i].seq {
+                                perf = true;
+                                break 'u2;
+                            }
+                        }
+                    }
+                }
+                if !perf {
+                    bads[u1] = true;
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
1. To determine assignment of chains to columns in a clonotype table, we now rely primarily on the column information implied by the original joins of exact subclonotypes.  This eliminates some artifactual behavior.  This is a major change to the algorithm, which is documented with new text
on the heuristics page.
2. Add improved code for diffing the results of two versions of enclone.
3. Add peak memory test.
4. Add sanity check to make_ann_region.
5. Improve ./test.
6. Update hdf5 crate.