### PR TITLE
Use license-file rather than license in Cargo.toml.

### DIFF
--- a/enclone/Cargo.toml
+++ b/enclone/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license = "LICENSE.txt"
+license-file = "../LICENSE.txt"
 publish = false
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml

--- a/enclone_print/Cargo.toml
+++ b/enclone_print/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license = "LICENSE.txt"
+license-file = "../LICENSE.txt"
 publish = false
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml

--- a/enclone_tail/Cargo.toml
+++ b/enclone_tail/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license = "LICENSE.txt"
+license-file = "../LICENSE.txt"
 publish = false
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml

--- a/enclone_versions/Cargo.toml
+++ b/enclone_versions/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license = "LICENSE.txt"
+license-file = "../LICENSE.txt"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
`license` is supposed to contain an SPDX 2.1 license expression.
[`license-file`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields) is the proper field to use for non-standard licenses.