### PR TITLE
CI: Target macOS 10.9 to fix spirv_cross

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,9 +36,9 @@ jobs:
           name: enclone
           path: artifacts
   macos:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     env:
-      MACOSX_DEPLOYMENT_TARGET: 10.7
+      MACOSX_DEPLOYMENT_TARGET: 10.9
     steps:
       - name: Checkout git repository
         uses: actions/checkout@master


### PR DESCRIPTION
Target macOS 10.9 building on macOS 10.15.

Fix the error:
```
fatal error: 'string' file not found
error: failed to run custom build command for `spirv_cross v0.23.1`
```
