### PR TITLE
CI: Run unit tests in enclone_exec

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: download test data
         run: git clone --depth=1 https://github.com/10XGenomics/enclone-data.git
       - name: unit tests
-        run: cd enclone_main; cargo test --release --features basic -- --nocapture
+        run: cd enclone_exec; cargo test --release --features basic -- --nocapture
 
   test-linux:
     # This job runs on Linux
@@ -135,4 +135,4 @@ jobs:
       - name: download test data
         run: git clone --depth=1 https://github.com/10XGenomics/enclone-data.git
       - name: unit tests
-        run: cd enclone_main; cargo test --release --features basic -- --nocapture
+        run: cd enclone_exec; cargo test --release --features basic -- --nocapture


### PR DESCRIPTION
Run unit tests in `enclone_exec` rather than `enclone_main`.

Fix the error:
```
error: Package `enclone_main v0.5.59` does not have the feature `basic`
```
