### PR TITLE
CI: Use a shared library for freetype on Linux

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,10 +26,11 @@ jobs:
           /bin/bash -lec '
           apt-get update
           && apt-get install -y libfreetype6-dev
-          && ln -s /usr/lib/x86_64-linux-gnu/libfreetype.a /mnt/build/toolchains/versions/latest/lib/
-          && cargo build --release
+          && ln -s /usr/lib/x86_64-linux-gnu/libfreetype.so /mnt/build/toolchains/versions/latest/lib/
+          && env -u PKG_CONFIG_LIBDIR cargo build --release
           && target/release/enclone --help | grep -q enclone
           && readelf -V target/release/enclone
+          && ldd target/release/enclone
           ';
           mkdir artifacts;
           cp -a target/release/enclone artifacts/enclone-linux


### PR DESCRIPTION
I don't recommend merging this PR, because the resulting `enclone` executable has a run-time dependency on `libfreetype.so.6` and `libpng16.so.16`, which must be provided by the users's OS. Getting static linking of these two libraries working is likely possible, but requires more effort.

```
ldd target/debug/enclone
	linux-vdso.so.1 (0x00007ffc957cf000)
	libfreetype.so.6 => /usr/lib/x86_64-linux-gnu/libfreetype.so.6 (0x00007f045796b000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f0457767000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f045754f000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f0457347000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f0457128000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f0456d8a000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f0456999000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f0457c1f000)
	libpng16.so.16 => /usr/lib/x86_64-linux-gnu/libpng16.so.16 (0x00007f0456767000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f045654a000)
```
