### PR TITLE
CI: Link statically to freetype on Linux

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,10 +26,16 @@ jobs:
           /bin/bash -lec '
           apt-get update
           && apt-get install -y libfreetype6-dev
-          && ln -s /usr/lib/x86_64-linux-gnu/libfreetype.a /mnt/build/toolchains/versions/latest/lib/
+          && ln -s
+            /usr/lib/x86_64-linux-gnu/libfreetype.a
+            /usr/lib/x86_64-linux-gnu/libfreetype.so
+            /mnt/build/toolchains/versions/latest/lib/
+          && env -u PKG_CONFIG_LIBDIR cargo check --release
+          && rm -f /mnt/build/toolchains/versions/latest/lib/libfreetype.so
           && cargo build --release
           && target/release/enclone --help | grep -q enclone
           && readelf -V target/release/enclone
+          && ldd target/release/enclone
           ';
           mkdir artifacts;
           cp -a target/release/enclone artifacts/enclone-linux


### PR DESCRIPTION
Use the shared freetype library for `cargo check`, compiling and running `build.rs`, and running `./configure`.
Use the static freetype library for `cargo build`, and linking `enclone`.

It’s a bit of a hack, but it seems to work. You’ll want to test copying the resulting `enclone` executable to another Linux laptop, and see if it actually works, and if the GUI works.

```
ldd target/release/enclone
	linux-vdso.so.1 (0x00007ffeee385000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f4ba26fb000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f4ba24e3000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f4ba22db000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f4ba20bc000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f4ba1d1e000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f4ba192d000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f4ba28ff000)
```
