### PR TITLE
Compress debug sections on Linux

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,3 +1,6 @@
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["--codegen=link-args=-Wl,--compress-debug-sections=zlib"]
+
 [alias]
 
 # "cargo t" exercises nearly the full test suite, except for the giant test "enclone.test"

--- a/enclone_exec/tests/enclone_test4.rs
+++ b/enclone_exec/tests/enclone_test4.rs
@@ -25,7 +25,7 @@ const LOUPE_OUT_FILENAME: &str = "testx/__test_proto";
 #[test]
 fn test_executable_size() {
     PrettyTrace::new().on();
-    const ENCLONE_SIZE: usize = 234120464;
+    const ENCLONE_SIZE: usize = 80518696;
     const ENCLONE_SIZE_MAX_PER_DIFF: f64 = 1.0;
     let f = format!("../target/debug/enclone");
     let n = metadata(&f).unwrap().len() as usize;


### PR DESCRIPTION
```
140M enclone_linux
 38M enclone_linux.gz
 56M enclone_linux-compress-debug-sections
 26M enclone_macos
```

Thanks to Adam for the tip-off about `--compress-debug-sections=zlib`.