### PR TITLE
Remove dependency on `time` crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,6 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
  "winapi",
 ]
 
@@ -3755,7 +3754,6 @@ checksum = "ab8809e0c18450a2db0f236d2a44ec0b4c1412d0eb936233579f0990faa5d5cd"
 dependencies = [
  "bitflags",
  "byteorder",
- "chrono",
  "flate2",
  "hex",
  "lazy_static",
@@ -4657,17 +4655,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ab1f382b10dd7ff9926b5c33374bc4011b27c82ee890c741aef2bd3fa0d10ba"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]

--- a/enclone_core/Cargo.toml
+++ b/enclone_core/Cargo.toml
@@ -26,7 +26,7 @@ ansi_escape = "0.1"
 attohttpc = { version = "0.17", default-features = false, features = ["compress", "tls-rustls"] }
 bio_edit = "0.1"
 bytes = "1"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 debruijn = "0.3"
 enclone_proto = { path = "../enclone_proto" }
 evalexpr = "6"
@@ -49,5 +49,5 @@ vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev="19f96f
 vector_utils = "0.1"
 
 [build-dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 string_utils = "0.1"

--- a/enclone_main/Cargo.toml
+++ b/enclone_main/Cargo.toml
@@ -22,7 +22,7 @@ publish = false
 [dependencies]
 amino = "0.1"
 bytes = "1"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 debruijn = "0.3"
 dirs = "3"
 enclone_core = { path = "../enclone_core" }

--- a/enclone_visual/Cargo.toml
+++ b/enclone_visual/Cargo.toml
@@ -24,7 +24,7 @@ publish = false
 # path = "src/bin/enclone.rs"
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 enclone_core = { path = "../enclone_core" }
 enclone_main = { path = "../enclone_main" }
 failure = "0.1"
@@ -60,7 +60,7 @@ vector_utils = "0.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 arboard = "1"
-procfs = "0.9"
+procfs = { version = "0.9", default_features = false }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 cocoa = "0.24"

--- a/master.toml
+++ b/master.toml
@@ -14,7 +14,7 @@ attohttpc = { version = "0.17", default-features = false, features = ["compress"
 bio_edit = "0.1"
 byteorder = "1"
 bytes = "1"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 cocoa = "0.24"
 debruijn = "0.3"
 dirs = "3"
@@ -58,7 +58,7 @@ plotters = { version = "0.3", default_features = false, features = ["svg_backend
 png-decoder = "0.1"
 pprof = "0.5"
 pretty_trace = "0.5"
-procfs = "0.9"
+procfs = { version = "0.9", default_features = false }
 prost = { version = "0.8", default_features = false }
 prost-build = "0.8"
 rand = "0.8"


### PR DESCRIPTION
chrono has an optional dependency on an older version of the `time`
crate.  We don't need that.