### PR TITLE
Do not fail the build when git fails

### DIFF
--- a/enclone_core/build.rs
+++ b/enclone_core/build.rs
@@ -46,8 +46,11 @@ fn get_commit_hash() -> String {
         .current_dir(env!("CARGO_MANIFEST_DIR"))
         .output()
         .unwrap();
-    assert!(output.status.success());
-    String::from_utf8_lossy(&output.stdout).to_string()
+    if output.status.success() {
+        String::from_utf8_lossy(&output.stdout).to_string()
+    } else {
+        "unknown".to_string()
+    }
 }
 
 fn is_github() -> bool {
@@ -79,10 +82,13 @@ fn get_branch_name() -> String {
         .current_dir(env!("CARGO_MANIFEST_DIR"))
         .output()
         .unwrap();
-    assert!(output.status.success());
-    String::from_utf8_lossy(&output.stdout)
-        .trim_end()
-        .to_string()
+    if output.status.success() {
+        String::from_utf8_lossy(&output.stdout)
+            .trim_end()
+            .to_string()
+    } else {
+        "unknown".to_string()
+    }
 }
 
 fn is_working_tree_clean() -> bool {


### PR DESCRIPTION
This change is needed to support building enclone outside of a Git repository (or if the `git` executable were not available). It is needed for some work that Adam is doing for remote Bazel builds.
