### PR TITLE
Symlink pages/enclone_css_v2.css to enclone_core/src/

### DIFF
--- a/enclone_core/src/enclone_css_v2.css
+++ b/enclone_core/src/enclone_css_v2.css
@@ -1,0 +1,1 @@
+../../pages/enclone_css_v2.css

--- a/enclone_core/src/print_tools.rs
+++ b/enclone_core/src/print_tools.rs
@@ -10,7 +10,7 @@ use string_utils::*;
 // Extract the @font-face content from the current css file.
 
 pub fn font_face_in_css() -> String {
-    let f = include_str!["../../pages/enclone_css_v2.css"];
+    let f = include_str!["enclone_css_v2.css"];
     let mut x = String::new();
     let mut in_font_face = false;
     let mut count = 0;


### PR DESCRIPTION
This change is needed for some work that Adam is doing for remote Bazel builds.
