### PR TITLE
Automated fixes from cargo clippy.

### DIFF
--- a/enclone/src/allele.rs
+++ b/enclone/src/allele.rs
@@ -2,17 +2,19 @@
 
 // This file provides functions to find alternate alleles and substitute them into references.
 
-use vdj_ann::*;
+use vdj_ann::refx;
 
-use self::refx::*;
-use debruijn::{dna_string::*, Mer};
-use enclone_core::defs::*;
+use self::refx::RefData;
+use debruijn::{dna_string::DnaString, Mer};
+use enclone_core::defs::{CloneInfo, EncloneControl, ExactClonotype};
 use itertools::Itertools;
 use rayon::prelude::*;
-use stats_utils::*;
-use std::cmp::*;
+use stats_utils::percent_ratio;
+use std::cmp::{max, PartialOrd};
 use std::time::Instant;
-use vector_utils::*;
+use vector_utils::{
+    erase_if, next_diff, next_diff1_2, next_diff1_3, next_diff1_5, reverse_sort, unique_sort,
+};
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone/src/bin/build_help_pages.rs
+++ b/enclone/src/bin/build_help_pages.rs
@@ -2,13 +2,13 @@
 
 // Build help pages, called by ./build.
 
-use enclone_core::defs::*;
-use io_utils::*;
-use pretty_trace::*;
+use enclone_core::defs::HELP_PAGES;
+use io_utils::{fwrite, open_for_write_new};
+use pretty_trace::PrettyTrace;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::process::Command;
-use string_utils::*;
+use string_utils::strme;
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone/src/bin/check_masters.rs
+++ b/enclone/src/bin/check_masters.rs
@@ -3,12 +3,12 @@
 // Find master.toml files repos in the given directory (e.g. ~/repos), and identify
 // inconsistencies.
 
-use io_utils::*;
-use pretty_trace::*;
+use io_utils::{dir_list, open_for_read, path_exists};
+use pretty_trace::PrettyTrace;
 use std::env;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
-use string_utils::*;
+use string_utils::TextUtils;
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone/src/bin/diff_enclone.rs
+++ b/enclone/src/bin/diff_enclone.rs
@@ -16,15 +16,15 @@
 //
 // Do not use any of the grouping arguments.
 
-use enclone::misc1::*;
+use enclone::misc1::setup_pager;
 use equiv::EquivRel;
 use itertools::Itertools;
-use pretty_trace::*;
+use pretty_trace::PrettyTrace;
 use std::collections::HashMap;
 use std::env;
 use std::process::Command;
-use string_utils::*;
-use vector_utils::*;
+use string_utils::{strme, TextUtils};
+use vector_utils::{bin_member, bin_position, next_diff1_2, unique_sort};
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone/src/bin/dup_crates.rs
+++ b/enclone/src/bin/dup_crates.rs
@@ -2,12 +2,12 @@
 
 // Find duplicated crates.
 
-use io_utils::*;
-use pretty_trace::*;
+use io_utils::open_for_read;
+use pretty_trace::PrettyTrace;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
-use string_utils::*;
-use vector_utils::*;
+use string_utils::TextUtils;
+use vector_utils::next_diff;
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone/src/bin/make_enclone_testlist_all.rs
+++ b/enclone/src/bin/make_enclone_testlist_all.rs
@@ -4,15 +4,15 @@
 //
 // This records the id and cellranger version.
 
-use enclone_core::defs::*;
-use enclone_core::testlist::*;
-use io_utils::*;
-use pretty_trace::*;
+use enclone_core::defs::get_config;
+use enclone_core::testlist::TEST_FILES_VERSION;
+use io_utils::{dir_list, fwriteln, open_for_read, open_for_write_new, path_exists};
+use pretty_trace::PrettyTrace;
 use std::collections::HashMap;
 use std::env;
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
-use string_utils::*;
+use string_utils::TextUtils;
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone/src/bin/start_release.rs
+++ b/enclone/src/bin/start_release.rs
@@ -4,18 +4,18 @@
 //
 // See enclone/release_instructions.
 
-use enclone_core::defs::*;
-use io_utils::*;
+use enclone_core::defs::get_config;
+use io_utils::{fwrite, open_for_read, open_for_write_new, path_exists};
 use itertools::Itertools;
-use pretty_trace::*;
+use pretty_trace::PrettyTrace;
 use std::collections::HashMap;
 use std::env;
 use std::fs::{read_dir, File};
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
-use string_utils::*;
-use vector_utils::*;
+use string_utils::{strme, TextUtils};
+use vector_utils::unique_sort;
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone/src/bin/sync_to_master.rs
+++ b/enclone/src/bin/sync_to_master.rs
@@ -3,13 +3,13 @@
 // Sync all the crate versions in the workspace to the versions defined in the file master.toml
 // in the top-level of the workspace.
 
-use io_utils::*;
+use io_utils::{fwrite, open_for_read, open_for_write_new, path_exists};
 use itertools::Itertools;
-use pretty_trace::*;
+use pretty_trace::PrettyTrace;
 use std::collections::HashMap;
 use std::fs::{read_dir, File};
 use std::io::{BufRead, BufReader, BufWriter, Write};
-use string_utils::*;
+use string_utils::TextUtils;
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone/src/bin/traceback1.rs
+++ b/enclone/src/bin/traceback1.rs
@@ -20,7 +20,7 @@ fn main() {
 
 #[test]
 fn test_traceback1() {
-    extern crate assert_cmd;
+    use assert_cmd;
     use assert_cmd::prelude::*;
     use enclone_core::*;
     use std::{env, process::Command};

--- a/enclone/src/bin/traceback1.rs
+++ b/enclone/src/bin/traceback1.rs
@@ -6,7 +6,7 @@
 // This was originally engineered without PrettyTrace, but the problem with this was that if the
 // test failed, you get a godawful mess that is impossible to distangle.
 
-use pretty_trace::*;
+use pretty_trace::PrettyTrace;
 use rayon::prelude::*;
 
 fn main() {
@@ -22,7 +22,7 @@ fn main() {
 fn test_traceback1() {
     use assert_cmd;
     use assert_cmd::prelude::*;
-    use enclone_core::*;
+    use enclone_core::version_string;
     use std::{env, process::Command};
     let mut cmd = Command::cargo_bin("traceback1").expect(
         "\nAttempt to run traceback1 failed.  The most likely explanation for this is that\n\

--- a/enclone/src/bin/update_enclone_binary.rs
+++ b/enclone/src/bin/update_enclone_binary.rs
@@ -3,9 +3,9 @@
 // Update the internally public enclone binary.  This is also done by start_release, but sometimes
 // one wants to update the binary without making a release.
 
-use enclone_core::defs::*;
-use io_utils::*;
-use pretty_trace::*;
+use enclone_core::defs::get_config;
+use io_utils::path_exists;
+use pretty_trace::PrettyTrace;
 use std::collections::HashMap;
 use std::env;
 use std::os::unix::fs::PermissionsExt;

--- a/enclone/src/graph_filter.rs
+++ b/enclone/src/graph_filter.rs
@@ -2,16 +2,16 @@
 
 // This file provides the single function graph_filter.
 
-use enclone_core::defs::*;
+use enclone_core::defs::{EncloneControl, TigData};
 use graph_simple::GraphSimple;
-use io_utils::*;
+use io_utils::fwriteln;
 use petgraph::prelude::*;
 use rayon::prelude::*;
-use std::cmp::*;
+use std::cmp::{max, min};
 use std::collections::HashMap;
 use std::io::Write;
-use string_utils::*;
-use vector_utils::*;
+use string_utils::strme;
+use vector_utils::{bin_member, bin_position, erase_if, lower_bound, next_diff12_3, reverse_sort};
 
 // Create a digraph which has one vertex for each V..J that appears in a productive
 // pair, and for a given light chain and a given heavy chain vertex, a weighted edge

--- a/enclone/src/info.rs
+++ b/enclone/src/info.rs
@@ -2,18 +2,18 @@
 
 // This file provides the single function build_info.
 
-use vdj_ann::*;
+use vdj_ann::refx;
 
-use self::refx::*;
-use amino::*;
-use ansi_escape::*;
-use debruijn::{dna_string::*, Mer};
-use enclone_core::defs::*;
-use enclone_core::print_tools::*;
+use self::refx::RefData;
+use amino::{aa_seq, codon_to_aa};
+use ansi_escape::emit_end_escape;
+use debruijn::{dna_string::DnaString, Mer};
+use enclone_core::defs::{CloneInfo, EncloneControl, ExactClonotype};
+use enclone_core::print_tools::emit_codon_color_escape;
 use rayon::prelude::*;
 use std::collections::HashMap;
-use string_utils::*;
-use vector_utils::*;
+use string_utils::strme;
+use vector_utils::unique_sort;
 
 pub fn build_info(
     refdata: &RefData,

--- a/enclone/src/innate.rs
+++ b/enclone/src/innate.rs
@@ -6,10 +6,10 @@
 // the TRAC sequence in the provided reference sequences, and the internally provided reference
 // sequences for human and mouse.
 
-use enclone_core::defs::*;
-use string_utils::*;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use enclone_core::defs::ExactClonotype;
+use string_utils::TextUtils;
+use vdj_ann::refx::{human_ref, mouse_ref, RefData};
+use vector_utils::{bin_member, reverse_sort, unique_sort};
 
 pub fn species(refdata: &RefData) -> String {
     let mut my_trac = Vec::<Vec<u8>>::new();

--- a/enclone/src/join.rs
+++ b/enclone/src/join.rs
@@ -7,23 +7,23 @@
 // contigs that represent the sequence of the "other" allele.  This does not look easy to
 // execute.
 
-use vdj_ann::*;
+use vdj_ann::{annotate, refx};
 
-use self::annotate::*;
-use self::refx::*;
-use crate::join2::*;
-use crate::join_core::*;
-use debruijn::dna_string::*;
-use enclone_core::defs::*;
+use self::annotate::print_annotations;
+use self::refx::RefData;
+use crate::join2::finish_join;
+use crate::join_core::join_core;
+use debruijn::dna_string::DnaString;
+use enclone_core::defs::{CloneInfo, EncloneControl, ExactClonotype, PotentialJoin};
 use equiv::EquivRel;
-use io_utils::*;
+use io_utils::{fwrite, fwriteln};
 use itertools::Itertools;
 use rayon::prelude::*;
-use std::cmp::*;
+use std::cmp::min;
 use std::collections::HashMap;
 use std::io::Write;
 use std::time::Instant;
-use vector_utils::*;
+use vector_utils::{bin_member, erase_if, next_diff1_2};
 
 pub fn join_exacts(
     is_bcr: bool,

--- a/enclone/src/join2.rs
+++ b/enclone/src/join2.rs
@@ -2,11 +2,11 @@
 
 // This file provides the tail end code for join.rs, plus a small function used there.
 
-use enclone_core::defs::*;
+use enclone_core::defs::{CloneInfo, EncloneControl};
 use equiv::EquivRel;
-use stats_utils::*;
+use stats_utils::percent_ratio;
 use std::time::Instant;
-use vector_utils::*;
+use vector_utils::next_diff1_2;
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone/src/join_core.rs
+++ b/enclone/src/join_core.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use enclone_core::defs::*;
-use enclone_core::join_one::*;
+use enclone_core::defs::{CloneInfo, EncloneControl, ExactClonotype, PotentialJoin};
+use enclone_core::join_one::join_one;
 use equiv::EquivRel;
 use std::collections::HashMap;
 

--- a/enclone/src/lib.rs
+++ b/enclone/src/lib.rs
@@ -1,7 +1,5 @@
 // Copyright (c) 2021 10x Genomics, Inc. All rights reserved.
 
-extern crate enclone_core;
-
 pub mod allele;
 pub mod graph_filter;
 pub mod info;

--- a/enclone/src/misc1.rs
+++ b/enclone/src/misc1.rs
@@ -2,16 +2,18 @@
 
 // Miscellaneous functions.
 
-use enclone_core::defs::*;
-use equiv::*;
-use itertools::*;
+use enclone_core::defs::{CloneInfo, EncloneControl, ExactClonotype, TigData};
+use equiv::EquivRel;
+use itertools::Itertools;
 #[cfg(not(target_os = "windows"))]
 use pager::Pager;
-use perf_stats::*;
+use perf_stats::elapsed;
 use std::collections::HashMap;
 use std::time::Instant;
-use string_utils::*;
-use vector_utils::*;
+use string_utils::stringme;
+use vector_utils::{
+    bin_member, bin_position, erase_if, next_diff, next_diff1_3, unique_sort, VecUtils,
+};
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone/src/misc2.rs
+++ b/enclone/src/misc2.rs
@@ -2,21 +2,23 @@
 
 // Miscellaneous functions.
 
-use crate::innate::*;
-use crate::misc3::*;
-use amino::*;
-use debruijn::dna_string::*;
-use enclone_core::defs::*;
-use io_utils::*;
+use crate::innate::mark_innate;
+use crate::misc3::study_consensus;
+use amino::aa_seq;
+use debruijn::dna_string::DnaString;
+use enclone_core::defs::{EncloneControl, ExactClonotype, TigData, TigData0, TigData1};
+use io_utils::{fwriteln, open_for_write_new};
 use rayon::prelude::*;
 use std::cmp::{max, min};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::time::Instant;
-use string_utils::*;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use string_utils::strme;
+use vdj_ann::refx::RefData;
+use vector_utils::{
+    erase_if, next_diff, next_diff12_4, next_diff1_2, next_diff1_3, reverse_sort, unique_sort,
+};
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone/src/misc3.rs
+++ b/enclone/src/misc3.rs
@@ -2,14 +2,14 @@
 
 // Miscellaneous functions.
 
-use enclone_core::defs::*;
-use io_utils::*;
-use itertools::*;
+use enclone_core::defs::{EncloneControl, ExactClonotype, TigData, TigData0, TigData1};
+use io_utils::{fwrite, fwriteln};
+use itertools::Itertools;
 use std::cmp::{max, min, Ordering};
 use std::io::Write;
-use string_utils::*;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use string_utils::strme;
+use vdj_ann::refx::RefData;
+use vector_utils::unique_sort;
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone/src/secret.rs
+++ b/enclone/src/secret.rs
@@ -11,11 +11,11 @@
 // (A)CH2-(B)CH3-CHS  [secreted]
 // (A)CH2-(B)Mx [membrane].
 
-use enclone_core::defs::*;
+use enclone_core::defs::EncloneControl;
 use std::collections::HashMap;
 use std::process::Command;
-use string_utils::*;
-use vector_utils::*;
+use string_utils::{stringme, strme, TextUtils};
+use vector_utils::next_diff1_3;
 
 // copied from tenkit2/pack_dna.rs:
 

--- a/enclone/src/subset_json.rs
+++ b/enclone/src/subset_json.rs
@@ -3,10 +3,10 @@
 // Extract the entries in a given all_contig_annotations.json file that corrrespond to barcodes
 // in a given sorted vector.
 
-use io_utils::*;
+use io_utils::open_userfile_for_read;
 use std::io::BufRead;
-use string_utils::*;
-use vector_utils::*;
+use string_utils::TextUtils;
+use vector_utils::bin_member;
 
 pub fn subset_all_contig_annotations_json(filename: &str, barcodes: &Vec<String>) -> String {
     let mut x = "[\n".to_string();

--- a/enclone_args/src/load_gex.rs
+++ b/enclone_args/src/load_gex.rs
@@ -3,13 +3,13 @@
 // Load gene expression and feature barcoding (antibody, antigen) data from
 // Cell Ranger outputs.
 
-use crate::load_gex_core::*;
-use enclone_core::defs::*;
+use crate::load_gex_core::load_gex;
+use enclone_core::defs::{EncloneControl, GexInfo};
 use hdf5::Dataset;
-use mirror_sparse_matrix::*;
+use mirror_sparse_matrix::MirrorSparseMatrix;
 use rayon::prelude::*;
 use std::{collections::HashMap, time::Instant};
-use vector_utils::*;
+use vector_utils::{bin_position, unique_sort};
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_args/src/load_gex_core.rs
+++ b/enclone_args/src/load_gex_core.rs
@@ -3,11 +3,13 @@
 // Load gene expression and feature barcoding (antibody, antigen) data from
 // Cell Ranger outputs.
 
-use enclone_core::defs::*;
-use enclone_core::slurp::*;
-use io_utils::*;
+use enclone_core::defs::EncloneControl;
+use enclone_core::slurp::slurp_h5;
+use io_utils::{dir_list, open_for_read, open_userfile_for_read, path_exists};
 use itertools::Itertools;
-use mirror_sparse_matrix::*;
+use mirror_sparse_matrix::{
+    get_code_version_from_file, read_from_file, write_to_file, MirrorSparseMatrix,
+};
 use rayon::prelude::*;
 use serde_json::Value;
 use std::{
@@ -17,8 +19,8 @@ use std::{
     io::{BufRead, BufReader, Read},
     time::Instant,
 };
-use string_utils::*;
-use vector_utils::*;
+use string_utils::{parse_csv, TextUtils};
+use vector_utils::{unique_sort, VecUtils};
 
 // parse_csv_pure: same as parse_csv, but don't strip out quotes
 

--- a/enclone_args/src/proc_args.rs
+++ b/enclone_args/src/proc_args.rs
@@ -1,16 +1,16 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use crate::proc_args2::*;
-use crate::proc_args_post::*;
-use crate::process_special_arg::*;
-use enclone_core::defs::*;
-use enclone_core::*;
-use io_utils::*;
+use crate::proc_args2::{is_f64_arg, is_i32_arg, is_simple_arg, is_string_arg, is_usize_arg};
+use crate::proc_args_post::proc_args_post;
+use crate::process_special_arg::process_special_arg;
+use enclone_core::defs::{ClonotypeHeuristics, EncloneControl};
+use enclone_core::require_readable_file;
+use io_utils::path_exists;
 use itertools::Itertools;
 use std::fs::{remove_file, File};
 use std::{process::Command, time::Instant};
-use string_utils::*;
-use tilde_expand::*;
+use string_utils::{stringme, strme, TextUtils};
+use tilde_expand::tilde_expand;
 
 // Process arguments.
 

--- a/enclone_args/src/proc_args2.rs
+++ b/enclone_args/src/proc_args2.rs
@@ -1,11 +1,11 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use enclone_core::defs::*;
-use io_utils::*;
+use enclone_core::defs::EncloneControl;
+use io_utils::{open_userfile_for_read, path_exists};
 use rayon::prelude::*;
 use std::{io::BufRead, time::Instant};
-use string_utils::*;
-use vector_utils::*;
+use string_utils::TextUtils;
+use vector_utils::next_diff;
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_args/src/proc_args3.rs
+++ b/enclone_args/src/proc_args3.rs
@@ -620,10 +620,7 @@ pub fn proc_xcr(
     // multithreading.
 
     let t = Instant::now();
-    let mut source = f.clone();
-    if f.contains('=') {
-        source = f.before("=");
-    }
+    let source = if f.contains('=') { f.before("=") } else { f };
     let mut results = Vec::<(String, String, bool, String)>::new();
     for (id, d) in donor_groups.iter().enumerate() {
         let origin_groups = (*d).split(':').collect::<Vec<&str>>();

--- a/enclone_args/src/proc_args3.rs
+++ b/enclone_args/src/proc_args3.rs
@@ -2,9 +2,9 @@
 
 // This file contains the two functions proc_xcr and proc_meta.
 
-use enclone_core::defs::*;
+use enclone_core::defs::{EncloneControl, OriginInfo};
 use enclone_core::fetch_url;
-use io_utils::*;
+use io_utils::{open_userfile_for_read, path_exists};
 use itertools::Itertools;
 use rayon::prelude::*;
 use std::collections::HashMap;
@@ -15,9 +15,9 @@ use std::sync::Arc;
 use std::thread;
 use std::time;
 use std::time::Instant;
-use string_utils::*;
-use tilde_expand::*;
-use vector_utils::*;
+use string_utils::{stringme, TextUtils};
+use tilde_expand::tilde_expand;
+use vector_utils::unique_sort;
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_args/src/proc_args_check.rs
+++ b/enclone_args/src/proc_args_check.rs
@@ -2,14 +2,17 @@
 
 // Check lvars, cvars, and pcols.
 
-use enclone_core::allowed_vars::*;
-use enclone_core::defs::*;
+use enclone_core::allowed_vars::{
+    CVARS_ALLOWED, CVARS_ALLOWED_PCELL, GVARS_ALLOWED, LVARS_ALLOWED, PCVARS_ALLOWED,
+    PLVARS_ALLOWED,
+};
+use enclone_core::defs::{EncloneControl, GexInfo};
 use itertools::Itertools;
 use rayon::prelude::*;
 use regex::Regex;
 use std::time::Instant;
-use string_utils::*;
-use vector_utils::*;
+use string_utils::{strme, TextUtils};
+use vector_utils::{bin_member, unique_sort};
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_args/src/proc_args_post.rs
+++ b/enclone_args/src/proc_args_post.rs
@@ -1,16 +1,16 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use crate::proc_args2::*;
-use crate::proc_args3::*;
-use crate::proc_args_check::*;
-use enclone_core::defs::*;
-use io_utils::*;
+use crate::proc_args2::proc_args_tail;
+use crate::proc_args3::{get_path_fail, proc_meta, proc_meta_core, proc_xcr};
+use crate::proc_args_check::check_cvars;
+use enclone_core::defs::EncloneControl;
+use io_utils::{open_for_read, open_userfile_for_read, path_exists};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::time::Instant;
-use string_utils::*;
-use tilde_expand::*;
-use vector_utils::*;
+use string_utils::{parse_csv, stringme, TextUtils};
+use tilde_expand::tilde_expand;
+use vector_utils::{next_diff, unique_sort};
 
 pub fn proc_args_post(
     mut ctl: &mut EncloneControl,

--- a/enclone_args/src/process_special_arg.rs
+++ b/enclone_args/src/process_special_arg.rs
@@ -2,18 +2,18 @@
 
 // Process a special argument, i.e. one that does not fit into a neat bucket.
 
-use crate::proc_args2::*;
-use enclone_core::cell_color::*;
-use enclone_core::defs::*;
-use enclone_core::linear_condition::*;
-use evalexpr::*;
-use io_utils::*;
+use crate::proc_args2::{is_f64_arg, is_simple_arg, is_usize_arg};
+use enclone_core::cell_color::{CellColor, ColorByVariableValue};
+use enclone_core::defs::EncloneControl;
+use enclone_core::linear_condition::LinearCondition;
+use evalexpr::build_operator_tree;
+use io_utils::path_exists;
 use itertools::Itertools;
 use regex::Regex;
 use std::fs::{remove_file, File};
-use string_utils::*;
-use tilde_expand::*;
-use vector_utils::*;
+use string_utils::{parse_csv, stringme, TextUtils};
+use tilde_expand::tilde_expand;
+use vector_utils::{unique_sort, VecUtils};
 
 pub fn process_special_arg(
     arg: &str,

--- a/enclone_args/src/read_json.rs
+++ b/enclone_args/src/read_json.rs
@@ -1,19 +1,19 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use self::annotate::*;
-use self::refx::*;
-use self::transcript::*;
-use debruijn::dna_string::*;
-use enclone_core::defs::*;
-use io_utils::*;
+use self::annotate::{annotate_seq, get_cdr3_using_ann, print_some_annotations};
+use self::refx::RefData;
+use self::transcript::is_valid;
+use debruijn::dna_string::DnaString;
+use enclone_core::defs::{EncloneControl, OriginInfo, TigData};
+use io_utils::{open_maybe_compressed, path_exists, read_vector_entry_from_json};
 use rayon::prelude::*;
 use serde_json::Value;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::{collections::HashMap, io::BufReader};
-use string_utils::*;
-use vdj_ann::*;
-use vector_utils::*;
+use string_utils::{stringme, strme, TextUtils};
+use vdj_ann::{annotate, refx, transcript};
+use vector_utils::{bin_position, unique_sort};
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_core/build.rs
+++ b/enclone_core/build.rs
@@ -6,9 +6,6 @@
 
 // This code is nearly identical to the code in enclone_version/src/lib.rs.
 
-extern crate chrono;
-extern crate string_utils;
-
 use chrono::prelude::*;
 use std::env::consts::{ARCH, OS};
 use std::process::Command;

--- a/enclone_core/build.rs
+++ b/enclone_core/build.rs
@@ -9,7 +9,7 @@
 use chrono::prelude::*;
 use std::env::consts::{ARCH, OS};
 use std::process::Command;
-use string_utils::*;
+use string_utils::TextUtils;
 
 #[cfg(debug_assertions)]
 const BUILD_TYPE: &str = "debug";

--- a/enclone_core/src/align_to_vdj_ref.rs
+++ b/enclone_core/src/align_to_vdj_ref.rs
@@ -21,11 +21,11 @@
 // "merge_html BUILD" and then manually examine the D gene page.  Note carefully that we do not
 // want to worsen the placement of indels.  Also run the above big test.
 
-use crate::defs::*;
-use bio_edit::alignment::pairwise::*;
+use crate::defs::EncloneControl;
+use bio_edit::alignment::pairwise::{Aligner, Scoring, MIN_SCORE};
 use bio_edit::alignment::AlignmentMode;
 use bio_edit::alignment::AlignmentOperation::*;
-use string_utils::*;
+use string_utils::strme;
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_core/src/align_to_vdj_ref.rs
+++ b/enclone_core/src/align_to_vdj_ref.rs
@@ -221,9 +221,9 @@ pub fn align_to_vdj_ref(
                 while j < ops.len() && ops[j] == Ins {
                     j += 1;
                 }
-                if rpos == vref.len() + dref.len() + d2ref.len() {
-                    score += gap_open_at_boundary + (j - i - 1) as i32 * gap_extend_at_boundary;
-                } else if rpos == vref.len() || rpos == vref.len() + dref.len() {
+                if (rpos == vref.len() + dref.len() + d2ref.len())
+                    || (rpos == vref.len() || rpos == vref.len() + dref.len())
+                {
                     score += gap_open_at_boundary + (j - i - 1) as i32 * gap_extend_at_boundary;
                 } else {
                     score += gap_open + (j - i - 1) as i32 * gap_extend;
@@ -309,11 +309,7 @@ pub fn align_to_vdj_ref(
     let b3 = vref.len() + dref.len() + d2ref.len();
     let mut edited = vec![false; ops.len()];
     while i < ops.len() {
-        if ops[i] == Match {
-            pos += 1;
-            rpos += 1;
-            i += 1;
-        } else if ops[i] == Subst {
+        if ops[i] == Match || ops[i] == Subst {
             pos += 1;
             rpos += 1;
             i += 1;

--- a/enclone_core/src/combine_group_pics.rs
+++ b/enclone_core/src/combine_group_pics.rs
@@ -1,11 +1,11 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use crate::defs::*;
-use ansi_escape::*;
-use io_utils::*;
+use crate::defs::justification;
+use ansi_escape::{emit_eight_bit_color_escape, emit_end_escape};
+use io_utils::{fwrite, fwriteln};
 use std::io::Write;
-use string_utils::*;
-use tables::*;
+use string_utils::{stringme, strme};
+use tables::print_tabular;
 
 pub fn combine_group_pics(
     group_pics: &Vec<String>,

--- a/enclone_core/src/convert_svg_to_png.rs
+++ b/enclone_core/src/convert_svg_to_png.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2021 10x Genomics, Inc. All rights reserved.
 
-use crc::*;
-use string_utils::*;
+use crc::{Crc, CRC_32_ISO_HDLC};
+use string_utils::stringme;
 
 // Modify a given PNG file by changing the pixels per meter to the given value.  This adds or
 // replaces a preexisting pHYs chunk in the file.  Note that presence of an iDOT chunk might

--- a/enclone_core/src/defs.rs
+++ b/enclone_core/src/defs.rs
@@ -1,13 +1,13 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use crate::cell_color::*;
-use crate::linear_condition::*;
-use debruijn::dna_string::*;
-use evalexpr::*;
+use crate::cell_color::CellColor;
+use crate::linear_condition::LinearCondition;
+use debruijn::dna_string::DnaString;
+use evalexpr::Node;
 use hdf5::Dataset;
-use io_utils::*;
-use mirror_sparse_matrix::*;
-use perf_stats::*;
+use io_utils::{open_for_read, path_exists};
+use mirror_sparse_matrix::MirrorSparseMatrix;
+use perf_stats::{elapsed, peak_mem_usage_gb};
 use regex::Regex;
 use std::cmp::max;
 use std::collections::HashMap;
@@ -15,8 +15,8 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::sync::atomic::AtomicBool;
 use std::time::{Instant, SystemTime};
-use string_utils::*;
-use vector_utils::*;
+use string_utils::TextUtils;
+use vector_utils::unique_sort;
 
 pub static FAILED: AtomicBool = AtomicBool::new(false);
 

--- a/enclone_core/src/join_one.rs
+++ b/enclone_core/src/join_one.rs
@@ -223,9 +223,7 @@ pub fn join_one(
                         } else {
                             share_pos_j[m].push(p);
                         }
-                    } else if t1 == r && t2 != r {
-                        indeps[u] += 1;
-                    } else if t2 == r && t1 != r {
+                    } else if (t1 == r && t2 != r) || (t2 == r && t1 != r) {
                         indeps[u] += 1;
                     } else if t1 != r && t2 != r {
                         indeps[u] += 2;

--- a/enclone_core/src/join_one.rs
+++ b/enclone_core/src/join_one.rs
@@ -1,11 +1,14 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use crate::defs::*;
-use debruijn::{dna_string::*, Mer};
-use stats_utils::*;
+use crate::defs::{CloneInfo, EncloneControl, ExactClonotype, PotentialJoin};
+use debruijn::{
+    dna_string::{ndiffs, DnaString},
+    Mer,
+};
+use stats_utils::abs_diff;
 use std::collections::HashMap;
-use stirling_numbers::*;
-use vector_utils::*;
+use stirling_numbers::p_at_most_m_distinct_in_sample_of_x_from_n;
+use vector_utils::{meet, unique_sort};
 
 // partial_bernoulli_sum( n, k ): return sum( choose(n,i), i = 0..=k ).
 //

--- a/enclone_core/src/lib.rs
+++ b/enclone_core/src/lib.rs
@@ -21,7 +21,7 @@ pub mod testlist;
 pub mod var_reg;
 pub mod vdj_features;
 
-use lazy_static::*;
+use lazy_static::lazy_static;
 use std::env;
 use std::io::BufRead;
 use std::sync::Mutex;

--- a/enclone_core/src/lib.rs
+++ b/enclone_core/src/lib.rs
@@ -79,7 +79,7 @@ pub fn parse_bsv(x: &str) -> Vec<String> {
 
 pub fn fetch_url(url: &str) -> Result<String, String> {
     const TIMEOUT: u64 = 120; // timeout in seconds
-    let req = attohttpc::get(url.clone()).read_timeout(Duration::new(TIMEOUT, 0));
+    let req = attohttpc::get(url).read_timeout(Duration::new(TIMEOUT, 0));
     let response = req.send();
     if response.is_err() {
         panic!("Failed to access URL {}.", url);
@@ -115,7 +115,7 @@ pub fn require_readable_file(f: &str, arg: &str) -> Result<(), String> {
         ));
     }
     let y = std::io::BufReader::new(x.unwrap());
-    for line in y.lines() {
+    if let Some(line) = y.lines().next() {
         if line.is_err() {
             let mut err = line.err().unwrap().to_string();
             if err.starts_with("Is a directory") {
@@ -127,7 +127,6 @@ pub fn require_readable_file(f: &str, arg: &str) -> Result<(), String> {
                 f, err, arg,
             ));
         }
-        break;
     }
     Ok(())
 }

--- a/enclone_core/src/linear_condition.rs
+++ b/enclone_core/src/linear_condition.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
 use crate::defs::EncloneControl;
-use string_utils::*;
+use string_utils::{stringme, TextUtils};
 
 #[derive(Clone, PartialEq)]
 pub struct LinearCondition {

--- a/enclone_core/src/mammalian_fixed_len.rs
+++ b/enclone_core/src/mammalian_fixed_len.rs
@@ -1,11 +1,11 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use crate::vdj_features::*;
-use amino::*;
+use crate::vdj_features::{cdr1_start, cdr2_start, cdr3_start, fr1_start, fr2_start, fr3_start};
+use amino::aa_seq;
 use std::collections::HashMap;
-use string_utils::*;
+use string_utils::TextUtils;
 use superslice::Ext;
-use vdj_ann::refx::*;
+use vdj_ann::refx::RefData;
 
 // {chain, feature, len, {{(count, amino_acid)}}}
 

--- a/enclone_core/src/opt_d.rs
+++ b/enclone_core/src/opt_d.rs
@@ -4,11 +4,11 @@
 // the donor V and J segments that are assigned to the clonotype.  Note that the optimal D
 // segment may be null.  This is obvious from looking at data.
 
-use crate::align_to_vdj_ref::*;
-use crate::defs::*;
-use enclone_proto::types::*;
+use crate::align_to_vdj_ref::{align_to_vdj_ref, match_bit_score, zero_one};
+use crate::defs::{ColInfo, EncloneControl, ExactClonotype};
+use enclone_proto::types::DonorReferenceItem;
 use std::cmp::min;
-use vdj_ann::refx::*;
+use vdj_ann::refx::RefData;
 
 pub fn vflank(_seq: &[u8], vref: &[u8]) -> usize {
     let mut flank = 13;

--- a/enclone_core/src/prepare_for_apocalypse.rs
+++ b/enclone_core/src/prepare_for_apocalypse.rs
@@ -7,11 +7,11 @@ use crate::version_string;
 use crate::{BUG_REPORT_ADDRESS, REMOTE_HOST};
 use chrono::{TimeZone, Utc};
 use itertools::Itertools;
-use pretty_trace::*;
+use pretty_trace::PrettyTrace;
 use std::env;
 use std::io::{Read, Write};
 use std::process::{Command, Stdio};
-use string_utils::*;
+use string_utils::TextUtils;
 
 pub fn prepare_for_apocalypse(args: &Vec<String>, email: bool, bug_reports: &str) {
     if email {

--- a/enclone_core/src/print_tools.rs
+++ b/enclone_core/src/print_tools.rs
@@ -1,9 +1,9 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use ansi_escape::*;
-use io_utils::*;
+use ansi_escape::{emit_end_escape, print_color};
+use io_utils::fwrite;
 use std::io::Write;
-use string_utils::*;
+use string_utils::strme;
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_core/src/set_speakers.rs
+++ b/enclone_core/src/set_speakers.rs
@@ -1,9 +1,9 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use crate::allowed_vars::*;
-use crate::defs::*;
-use string_utils::*;
-use vector_utils::*;
+use crate::allowed_vars::{CVARS_ALLOWED, CVARS_ALLOWED_PCELL, LVARS_ALLOWED};
+use crate::defs::EncloneControl;
+use string_utils::TextUtils;
+use vector_utils::bin_member;
 
 // Define the set "parseable_fields" of fields that could occur in parseable output.
 //

--- a/enclone_core/src/vdj_features.rs
+++ b/enclone_core/src/vdj_features.rs
@@ -11,8 +11,8 @@
 // modified to add a fake leader sequence on the left (we use MXXXXXXXXXXXXXXXXXXXX), and to
 // truncate on the right to trim a bit beyond the start of the CDR3.
 
-use string_utils::*;
-use vector_utils::*;
+use string_utils::strme;
+use vector_utils::{reverse_sort, sort_sync3};
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_denovo/src/bin/analyze_const.rs
+++ b/enclone_denovo/src/bin/analyze_const.rs
@@ -5,10 +5,10 @@
 // usage: analyze_igh_data x
 //        where x is a or d or e or g or m (heavy chains) or k or l (light chains)
 
-use pretty_trace::*;
+use pretty_trace::PrettyTrace;
 use std::env;
-use string_utils::*;
-use vector_utils::*;
+use string_utils::{abbrev_list, TextUtils};
+use vector_utils::{make_freq, sort_sync2};
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone_denovo/src/bin/convert_fasta.rs
+++ b/enclone_denovo/src/bin/convert_fasta.rs
@@ -4,9 +4,9 @@
 //
 // Usage convert_fasta in-file out-file
 
-use binary_vec_io::*;
-use fasta_tools::*;
-use pretty_trace::*;
+use binary_vec_io::binary_write_vec_vec;
+use fasta_tools::read_fasta_to_vec_vec_u8;
+use pretty_trace::PrettyTrace;
 use std::env;
 use std::fs::File;
 

--- a/enclone_denovo/src/bin/download_genbank_assembly.rs
+++ b/enclone_denovo/src/bin/download_genbank_assembly.rs
@@ -6,10 +6,10 @@
 // in the directory where you want the file.
 // Creates GCA_id.n.fasta.gz.
 
-use pretty_trace::*;
+use pretty_trace::PrettyTrace;
 use std::env;
 use std::process::Command;
-use string_utils::*;
+use string_utils::TextUtils;
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone_denovo/src/bin/download_isoseq.rs
+++ b/enclone_denovo/src/bin/download_isoseq.rs
@@ -12,11 +12,11 @@
 //
 // It has also failed on occasion.
 
-use pretty_trace::*;
+use pretty_trace::PrettyTrace;
 use std::fs::read_dir;
 use std::process::Command;
-use string_utils::*;
-use vector_utils::*;
+use string_utils::{strme, TextUtils};
+use vector_utils::bin_member;
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone_denovo/src/bin/download_mammals.rs
+++ b/enclone_denovo/src/bin/download_mammals.rs
@@ -9,13 +9,13 @@
 //
 // This should put the temp fasta file in /mnt/assembly or better yet not create a file at all.
 
-use binary_vec_io::*;
-use fasta_tools::*;
-use pretty_trace::*;
+use binary_vec_io::binary_write_vec_vec;
+use fasta_tools::read_fasta_to_vec_vec_u8;
+use pretty_trace::PrettyTrace;
 use std::fs::{read_dir, File};
 use std::process::Command;
-use string_utils::*;
-use vector_utils::*;
+use string_utils::TextUtils;
+use vector_utils::bin_member;
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone_denovo/src/bin/download_one_isoseq.rs
+++ b/enclone_denovo/src/bin/download_one_isoseq.rs
@@ -2,10 +2,10 @@
 //
 // Download one isoseq dataset.
 
-use pretty_trace::*;
+use pretty_trace::PrettyTrace;
 use std::env;
 use std::process::Command;
-use string_utils::*;
+use string_utils::strme;
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone_denovo/src/bin/shrink_fasta.rs
+++ b/enclone_denovo/src/bin/shrink_fasta.rs
@@ -5,13 +5,13 @@
 //
 // Usage shrink_fasta in-file out-file
 
-use fasta_tools::*;
-use io_utils::*;
-use pretty_trace::*;
+use fasta_tools::read_fasta_to_vec_vec_u8;
+use io_utils::{fwrite, fwriteln, open_for_write_new};
+use pretty_trace::PrettyTrace;
 use std::env;
 use std::fs::File;
 use std::io::{BufWriter, Write};
-use string_utils::*;
+use string_utils::strme;
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone_denovo/src/bin/squeeze_novo.rs
+++ b/enclone_denovo/src/bin/squeeze_novo.rs
@@ -6,12 +6,12 @@
 // e.g. squeeze_novo FWR3 39
 // optional extra arg: a string that full reference names should match
 
-use amino::*;
-use enclone_denovo::vdj_features::*;
-use fasta_tools::*;
-use pretty_trace::*;
+use amino::aa_seq;
+use enclone_denovo::vdj_features::{cdr1, cdr2, fwr1, fwr2, fwr3};
+use fasta_tools::read_fasta_to_vec_vec_u8;
+use pretty_trace::PrettyTrace;
 use std::env;
-use string_utils::*;
+use string_utils::{strme, TextUtils};
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone_denovo/src/bin/sync_to_genome_list.rs
+++ b/enclone_denovo/src/bin/sync_to_genome_list.rs
@@ -7,11 +7,11 @@
 //
 // This provides a vehicle for managing the names of the genome files.
 
-use pretty_trace::*;
+use pretty_trace::PrettyTrace;
 use std::env;
 use std::fs::{read_dir, rename};
-use string_utils::*;
-use vector_utils::*;
+use string_utils::TextUtils;
+use vector_utils::{bin_member, sort_sync2};
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone_denovo/src/bin/test_const_ighd.rs
+++ b/enclone_denovo/src/bin/test_const_ighd.rs
@@ -4,16 +4,16 @@
 //
 // This will break when we change denovo.rs to not just run IGHD.
 
-use io_utils::*;
+use io_utils::fwriteln;
 use itertools::Itertools;
-use perf_stats::*;
-use pretty_trace::*;
+use perf_stats::elapsed;
+use pretty_trace::PrettyTrace;
 use rayon::prelude::*;
 use std::io::Write;
 use std::process::Command;
 use std::time::Instant;
-use string_utils::*;
-use vector_utils::*;
+use string_utils::{strme, TextUtils};
+use vector_utils::unique_sort;
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone_denovo/src/const_ighd.rs
+++ b/enclone_denovo/src/const_ighd.rs
@@ -2,7 +2,12 @@
 
 // Code to help find IGHD constant regions.
 
-use std::arch::x86_64::*;
+use std::arch::x86_64::{
+    __m128, __m128i, __m256, _mm256_add_epi32, _mm256_add_ps, _mm256_castps256_ps128,
+    _mm256_cvtepu8_epi32, _mm256_extractf128_ps, _mm256_i32gather_ps, _mm256_mullo_epi32,
+    _mm256_set1_epi32, _mm256_set1_ps, _mm256_setr_epi32, _mm_add_ps, _mm_add_ss, _mm_cvtss_f32,
+    _mm_loadu_si128, _mm_movehdup_ps, _mm_movehl_ps,
+};
 
 // Score relative to IGHD PWM.
 

--- a/enclone_denovo/src/make_fwr3_freqs.rs
+++ b/enclone_denovo/src/make_fwr3_freqs.rs
@@ -3,14 +3,14 @@
 // Compute FWR3 for all IMGT mammalian reference sequences, and report out a per-chain
 // amino acid frequency table.
 
-use crate::vdj_features::*;
-use amino::*;
-use debruijn::dna_string::*;
-use fasta_tools::*;
+use crate::vdj_features::{cdr3_score, cdr3_start, fr3_start};
+use amino::aa_seq;
+use debruijn::dna_string::DnaString;
+use fasta_tools::read_fasta_into_vec_dna_string_plus_headers;
 use std::fs::read_dir;
-use string_utils::*;
+use string_utils::TextUtils;
 // use vdj_ann::refx::*;
-use vector_utils::*;
+use vector_utils::make_freq;
 
 pub fn make_fwr3_freqs() -> Vec<Vec<Vec<(u32, u8)>>> {
     // Define constants.

--- a/enclone_denovo/src/make_mammalian_fixed_len.rs
+++ b/enclone_denovo/src/make_mammalian_fixed_len.rs
@@ -3,13 +3,13 @@
 // From IMGT mammalian reference sequences, find the
 // (per chain, per feature, per length, per position) amino acid distribution.
 
-use crate::vdj_features::*;
-use amino::*;
-use debruijn::dna_string::*;
-use fasta_tools::*;
+use crate::vdj_features::{cdr1, cdr2, cdr3_score, fwr1, fwr2, fwr3};
+use amino::aa_seq;
+use debruijn::dna_string::DnaString;
+use fasta_tools::read_fasta_into_vec_dna_string_plus_headers;
 use std::fs::read_dir;
-use string_utils::*;
-use vector_utils::*;
+use string_utils::TextUtils;
+use vector_utils::make_freq;
 
 pub fn make_mammalian_fixed_len() -> Vec<(String, String, usize, Vec<Vec<(u32, u8)>>)> {
     // Set up to track calls.

--- a/enclone_denovo/src/make_mammalian_pwms.rs
+++ b/enclone_denovo/src/make_mammalian_pwms.rs
@@ -17,19 +17,19 @@
 // 3. Other reference sequences are aligned to the smallest length that is at least that length,
 // and then the PWM is updated.  We ignore sequences that have insertions.
 
-use crate::vdj_features::*;
-use amino::*;
-use bio::alignment::pairwise::banded::*;
+use crate::vdj_features::{cdr1, cdr2, cdr3_score, fwr1, fwr2, fwr3};
+use amino::aa_seq;
+use bio::alignment::pairwise::banded::Aligner;
 use bio::alignment::AlignmentOperation::Del;
 use bio::alignment::AlignmentOperation::Ins;
-use debruijn::dna_string::*;
-use fasta_tools::*;
+use debruijn::dna_string::DnaString;
+use fasta_tools::read_fasta_into_vec_dna_string_plus_headers;
 use std::cmp::max;
 use std::collections::HashMap;
 use std::fs::read_dir;
-use string_utils::*;
+use string_utils::TextUtils;
 use superslice::Ext;
-use vector_utils::*;
+use vector_utils::make_freq;
 
 pub fn make_mammalian_pwms() -> Vec<(String, String, usize, Vec<Vec<(u32, u8)>>)> {
     // Define reference sequence data.

--- a/enclone_denovo/src/mammalian_fixed_len.rs
+++ b/enclone_denovo/src/mammalian_fixed_len.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2020 10X Genomics, Inc. All rights reserved.
 
-use string_utils::*;
+use string_utils::TextUtils;
 
 pub fn mammalian_fixed_len() -> Vec<(String, String, usize, Vec<Vec<(u32, u8)>>)> {
     let mut p = Vec::<(String, String, usize, Vec<Vec<(u32, u8)>>)>::new();

--- a/enclone_denovo/src/mammalian_pwms.rs
+++ b/enclone_denovo/src/mammalian_pwms.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2020 10X Genomics, Inc. All rights reserved.
 
-use string_utils::*;
+use string_utils::TextUtils;
 
 pub fn mammalian_pwms() -> Vec<(String, String, usize, Vec<Vec<(u32, u8)>>)> {
     let mut p = Vec::<(String, String, usize, Vec<Vec<(u32, u8)>>)>::new();

--- a/enclone_denovo/src/vdj_features.rs
+++ b/enclone_denovo/src/vdj_features.rs
@@ -13,8 +13,8 @@
 
 // THIS IS A COPY FROM THE ENCLONE REPO TO FACILITATE EXPERIMENTATION!
 
-use string_utils::*;
-use vector_utils::*;
+use string_utils::strme;
+use vector_utils::reverse_sort;
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_help/src/help1.rs
+++ b/enclone_help/src/help1.rs
@@ -2,7 +2,7 @@
 
 // Test for help request.
 
-use crate::help_utils::*;
+use crate::help_utils::HelpDesk;
 
 pub fn help1(args: &Vec<String>, h: &mut HelpDesk) -> Result<(), String> {
     // Provide main help.

--- a/enclone_help/src/help2.rs
+++ b/enclone_help/src/help2.rs
@@ -2,11 +2,11 @@
 
 // Test for help request.
 
-use crate::help_utils::*;
-use enclone_core::defs::*;
-use enclone_core::testlist::*;
+use crate::help_utils::HelpDesk;
+use enclone_core::defs::EncloneControl;
+use enclone_core::testlist::EXAMPLES;
 use itertools::Itertools;
-use string_utils::*;
+use string_utils::strme;
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_help/src/help2.rs
+++ b/enclone_help/src/help2.rs
@@ -93,7 +93,7 @@ pub fn help2(args: &Vec<String>, _ctl: &EncloneControl, h: &mut HelpDesk) -> Res
         let mut ex2_args2 = Vec::<&str>::new();
         for i in 0..ex2_args.len() {
             if ex2_args[i] != "H5" {
-                ex2_args2.push(ex2_args[i].clone());
+                ex2_args2.push(ex2_args[i]);
             }
         }
 

--- a/enclone_help/src/help3.rs
+++ b/enclone_help/src/help3.rs
@@ -2,8 +2,8 @@
 //
 // Test for help request, under development.
 
-use crate::help_utils::*;
-use tables::*;
+use crate::help_utils::HelpDesk;
+use tables::print_tabular_vbox;
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_help/src/help4.rs
+++ b/enclone_help/src/help4.rs
@@ -2,8 +2,8 @@
 //
 // Test for help request, under development.
 
-use crate::help_utils::*;
-use tables::*;
+use crate::help_utils::{gray_left_bar, print_to, HelpDesk};
+use tables::print_tabular_vbox;
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_help/src/help5.rs
+++ b/enclone_help/src/help5.rs
@@ -2,14 +2,14 @@
 //
 // Test for help request, under development.
 
-use crate::help_utils::*;
-use ansi_escape::*;
-use enclone_core::defs::*;
-use enclone_core::print_tools::*;
-use enclone_core::*;
-use io_utils::*;
+use crate::help_utils::{colored_codon_table, HelpDesk};
+use ansi_escape::{best_color_order, emit_end_escape, emit_green_escape, print_color};
+use enclone_core::defs::EncloneControl;
+use enclone_core::print_tools::color_by_property;
+use enclone_core::version_string;
+use io_utils::fwrite;
 use std::io::Write;
-use string_utils::*;
+use string_utils::{stringme, strme};
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_help/src/help_utils.rs
+++ b/enclone_help/src/help_utils.rs
@@ -1,12 +1,15 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use ansi_escape::ansi_to_html::*;
-use ansi_escape::*;
-use enclone_core::print_tools::*;
-use io_utils::*;
+use ansi_escape::ansi_to_html::convert_text_with_ansi_escapes_to_html;
+use ansi_escape::{
+    emit_blue_escape, emit_bold_escape, emit_end_escape, emit_green_escape, emit_red_escape,
+    print_color,
+};
+use enclone_core::print_tools::{emit_codon_color_escape, font_face_in_css};
+use io_utils::fwrite;
 use std::io::Write;
-use string_utils::*;
-use tables::*;
+use string_utils::{stringme, strme};
+use tables::print_tabular_vbox;
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_help/src/lib.rs
+++ b/enclone_help/src/lib.rs
@@ -1,7 +1,5 @@
 // Copyright (c) 2021 10x Genomics, Inc. All rights reserved.
 
-extern crate enclone_core;
-
 pub mod help1;
 pub mod help2;
 pub mod help3;

--- a/enclone_main/src/determine_ref.rs
+++ b/enclone_main/src/determine_ref.rs
@@ -2,15 +2,17 @@
 
 // Start of code to determine the reference sequence that is to be used.
 
-use enclone_core::defs::*;
-use io_utils::*;
+use enclone_core::defs::EncloneControl;
+use io_utils::{open_for_read, open_maybe_compressed, path_exists, read_vector_entry_from_json};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
-use string_utils::*;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use string_utils::{strme, TextUtils};
+use vdj_ann::refx::{
+    human_ref, human_ref_2_0, human_ref_3_1, human_ref_4_0, mouse_ref, mouse_ref_3_1, mouse_ref_4_0,
+};
+use vector_utils::{erase_if, unique_sort, VecUtils};
 
 pub fn determine_ref(ctl: &mut EncloneControl, refx: &mut String) -> Result<(), String> {
     // First check for the existence of a json file.

--- a/enclone_main/src/disintegrate.rs
+++ b/enclone_main/src/disintegrate.rs
@@ -20,7 +20,10 @@ pub fn disintegrate_onesies(
 ) {
     if ctl.clono_filt_opt_def.weak_onesies {
         let t = Instant::now();
-        let ncells_total = exact_clonotypes.iter().map(|x| x.ncells()).sum();
+        let ncells_total = exact_clonotypes
+            .iter()
+            .map(enclone_core::defs::ExactClonotype::ncells)
+            .sum();
         let mut to_info = HashMap::<usize, usize>::new();
         let mut exacts2 = Vec::<ExactClonotype>::new();
         for i in 0..info.len() {

--- a/enclone_main/src/disintegrate.rs
+++ b/enclone_main/src/disintegrate.rs
@@ -3,11 +3,11 @@
 // If NWEAK_ONESIES is not specified, disintegrate certain onesie clonotypes into single cell
 // clonotypes.  This requires editing of exact_clonotypes, info, eq, join_info and raw_joins.
 
-use enclone_core::defs::*;
+use enclone_core::defs::{CloneInfo, EncloneControl, ExactClonotype};
 use equiv::EquivRel;
 use std::collections::HashMap;
 use std::time::Instant;
-use vector_utils::*;
+use vector_utils::unique_sort;
 
 pub fn disintegrate_onesies(
     ctl: &EncloneControl,

--- a/enclone_main/src/doublets.rs
+++ b/enclone_main/src/doublets.rs
@@ -4,12 +4,12 @@
 //
 // THIS FILTER DOESN'T PROPERLY TRACK FATE.
 
-use enclone_core::defs::*;
-use enclone_print::define_mat::*;
+use enclone_core::defs::{CloneInfo, EncloneControl, ExactClonotype};
+use enclone_print::define_mat::define_mat;
 use itertools::Itertools;
 use rayon::prelude::*;
 use std::collections::HashMap;
-use vector_utils::*;
+use vector_utils::{bin_member, erase_if, next_diff, next_diff12_3, next_diff1_2, sort_sync2};
 
 pub fn delete_doublets(
     orbits: &mut Vec<Vec<i32>>,

--- a/enclone_main/src/fcell.rs
+++ b/enclone_main/src/fcell.rs
@@ -2,18 +2,18 @@
 
 // Filter using constraints imposed by FCELL.
 
-use enclone_core::defs::*;
-use enclone_print::proc_lvar1::*;
-use evalexpr::*;
-use io_utils::*;
+use enclone_core::defs::{CloneInfo, EncloneControl, ExactClonotype, GexInfo};
+use enclone_print::proc_lvar1::get_gex_matrix_entry;
+use evalexpr::{ContextWithMutableVariables, HashMapContext};
+use io_utils::{dir_list, path_exists};
 use ndarray::s;
 use rayon::prelude::*;
 use std::env;
 use std::thread;
 use std::time;
 use std::time::Instant;
-use string_utils::*;
-use vector_utils::*;
+use string_utils::TextUtils;
+use vector_utils::{bin_position, erase_if};
 
 pub fn filter_by_fcell(
     ctl: &EncloneControl,

--- a/enclone_main/src/filter_umi.rs
+++ b/enclone_main/src/filter_umi.rs
@@ -2,12 +2,12 @@
 
 // Filter B cells based on UMI counts.
 
-use enclone_core::defs::*;
+use enclone_core::defs::{CloneInfo, EncloneControl, ExactClonotype};
 use equiv::EquivRel;
-use stats_utils::*;
+use stats_utils::binomial_sum;
 use std::cmp::max;
 use std::collections::HashMap;
-use vector_utils::*;
+use vector_utils::{erase_if, next_diff1_5, reverse_sort, VecUtils};
 
 pub fn filter_umi(
     eq: &EquivRel,

--- a/enclone_main/src/flag_defective.rs
+++ b/enclone_main/src/flag_defective.rs
@@ -2,15 +2,15 @@
 
 // Flag defective reference sequences.
 
-use amino::*;
-use enclone_core::defs::*;
-use enclone_core::vdj_features::*;
-use io_utils::*;
+use amino::aa_seq;
+use enclone_core::defs::EncloneControl;
+use enclone_core::vdj_features::{cdr2_start, cdr3_score, fr3_start, score4, score_fwr3};
+use io_utils::fwriteln;
 use itertools::Itertools;
 use std::io::Write;
-use string_utils::*;
+use string_utils::{strme, TextUtils};
 use vdj_ann::refx::RefData;
-use vector_utils::*;
+use vector_utils::unique_sort;
 
 pub fn flag_defective(
     ctl: &EncloneControl,

--- a/enclone_main/src/inconsistent.rs
+++ b/enclone_main/src/inconsistent.rs
@@ -14,11 +14,11 @@
 // This code is inefficient because for every dataset, it searches the entirety of tig_bc, but
 // it doesn't matter much because not much time is spent here.
 
-use enclone_core::defs::*;
+use enclone_core::defs::{EncloneControl, ExactClonotype, GexInfo, TigData};
 use rayon::prelude::*;
-use stats_utils::*;
+use stats_utils::binomial_sum;
 use std::time::Instant;
-use vector_utils::*;
+use vector_utils::{bin_member, bin_position, reverse_sort};
 
 pub fn test_vdj_gex_inconsistent(
     ctl: &EncloneControl,

--- a/enclone_main/src/main_enclone.rs
+++ b/enclone_main/src/main_enclone.rs
@@ -176,14 +176,13 @@ pub fn main_enclone_setup(args: &Vec<String>) -> Result<EncloneSetup, String> {
     ctl.gen_opt.cpu_this_start = 0;
     if ctl.gen_opt.print_cpu || ctl.gen_opt.print_cpu_info {
         let f = open_for_read!["/proc/stat"];
-        for line in f.lines() {
+        if let Some(line) = f.lines().next() {
             let s = line.unwrap();
             let mut t = s.after("cpu");
             while t.starts_with(' ') {
                 t = t.after(" ");
             }
             ctl.gen_opt.cpu_all_start = t.before(" ").force_usize();
-            break;
         }
         let f = open_for_read![&format!("/proc/{}/stat", std::process::id())];
         for line in f.lines() {
@@ -366,7 +365,7 @@ pub fn main_enclone_setup(args: &Vec<String>) -> Result<EncloneSetup, String> {
                     test2.push(var.to_string());
                 }
             }
-            for _ in con.iter_function_identifiers() {
+            if let Some(_) = con.iter_function_identifiers().next() {
                 return Err("\nSomething is wrong with your FCELL value.\n".to_string());
             }
         }

--- a/enclone_main/src/main_enclone.rs
+++ b/enclone_main/src/main_enclone.rs
@@ -2,42 +2,42 @@
 //
 // See README for documentation.
 
-use self::refx::*;
-use crate::blacklist::*;
-use crate::determine_ref::*;
-use crate::disintegrate::*;
-use crate::fcell::*;
-use crate::filter_umi::*;
-use crate::flag_defective::*;
-use crate::inconsistent::*;
-use crate::populate_features::*;
-use crate::sec_mem::*;
-use crate::setup::*;
-use crate::some_filters::*;
-use crate::stop::*;
-use crate::vars::*;
+use self::refx::{make_vdj_ref_data_core, RefData};
+use crate::blacklist::profiling_blacklist;
+use crate::determine_ref::determine_ref;
+use crate::disintegrate::disintegrate_onesies;
+use crate::fcell::filter_by_fcell;
+use crate::filter_umi::filter_umi;
+use crate::flag_defective::flag_defective;
+use crate::inconsistent::test_vdj_gex_inconsistent;
+use crate::populate_features::populate_features;
+use crate::sec_mem::test_sec_mem;
+use crate::setup::{critical_args, setup};
+use crate::some_filters::some_filters;
+use crate::stop::{main_enclone_stop, EncloneExacts, EncloneIntermediates};
+use crate::vars::match_vars;
 use debruijn::dna_string::DnaString;
-use enclone::allele::*;
-use enclone::graph_filter::*;
-use enclone::info::*;
-use enclone::innate::*;
-use enclone::join::*;
-use enclone::misc1::*;
-use enclone::misc2::*;
-use enclone::misc3::*;
-use enclone::secret::*;
-use enclone_args::load_gex::*;
-use enclone_args::proc_args2::*;
-use enclone_args::proc_args_check::*;
-use enclone_args::read_json::*;
-use enclone_core::cell_color::*;
-use enclone_core::defs::*;
-use enclone_core::*;
-use enclone_print::loupe::*;
+use enclone::allele::{find_alleles, sub_alts};
+use enclone::graph_filter::graph_filter;
+use enclone::info::build_info;
+use enclone::innate::species;
+use enclone::join::join_exacts;
+use enclone::misc1::{cross_filter, lookup_heavy_chain_reuse};
+use enclone::misc2::{check_for_barcode_reuse, find_exact_subclonotypes, search_for_shm_indels};
+use enclone::misc3::sort_tig_bc;
+use enclone::secret::fetch_secmem;
+use enclone_args::load_gex::get_gex_info;
+use enclone_args::proc_args2::is_simple_arg;
+use enclone_args::proc_args_check::{check_gvars, check_lvars, check_pcols, get_known_features};
+use enclone_args::read_json::parse_json_annotations_files;
+use enclone_core::cell_color::CellColor;
+use enclone_core::defs::{CloneInfo, EncloneControl, GexInfo, TigData};
+use enclone_core::version_string;
+use enclone_print::loupe::make_donor_refs;
 use equiv::EquivRel;
-use io_utils::*;
+use io_utils::{fwriteln, open_for_read, open_userfile_for_read, path_exists};
 use itertools::Itertools;
-use pretty_trace::*;
+use pretty_trace::start_profiling;
 use std::{
     collections::HashMap,
     env, fs,
@@ -45,10 +45,10 @@ use std::{
     io::{BufRead, BufReader, BufWriter, Write},
     time::Instant,
 };
-use stirling_numbers::*;
-use string_utils::*;
-use vdj_ann::*;
-use vector_utils::*;
+use stirling_numbers::stirling2_ratio_table;
+use string_utils::TextUtils;
+use vdj_ann::refx;
+use vector_utils::{bin_member, erase_if, next_diff, unique_sort};
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_main/src/merge_onesies.rs
+++ b/enclone_main/src/merge_onesies.rs
@@ -2,9 +2,9 @@
 
 // Merge onesies where totally unambiguous.  Possibly inefficient and should optimize.
 
-use enclone_core::defs::*;
+use enclone_core::defs::{CloneInfo, EncloneControl, ExactClonotype};
 use equiv::EquivRel;
-use vector_utils::*;
+use vector_utils::{lower_bound1_2, unique_sort, upper_bound1_2};
 
 pub fn merge_onesies(
     orbits: &mut Vec<Vec<i32>>,

--- a/enclone_main/src/opt_d_val.rs
+++ b/enclone_main/src/opt_d_val.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2021 10x Genomics, Inc. All rights reserved.
 
-use enclone_core::defs::*;
-use enclone_core::opt_d::*;
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype};
+use enclone_core::opt_d::opt_d;
 use enclone_proto::types::DonorReferenceItem;
 use rayon::prelude::*;
 use std::time::Instant;

--- a/enclone_main/src/populate_features.rs
+++ b/enclone_main/src/populate_features.rs
@@ -2,13 +2,13 @@
 
 // Populate features.
 
-use amino::*;
-use enclone_core::defs::*;
-use enclone_core::vdj_features::*;
-use io_utils::*;
+use amino::aa_seq;
+use enclone_core::defs::EncloneControl;
+use enclone_core::vdj_features::{cdr1_start, cdr2_start, fr1_start, fr2_start, fr3_start};
+use io_utils::fwriteln;
 use std::io::Write;
-use string_utils::*;
-use tables::*;
+use string_utils::{stringme, strme};
+use tables::print_tabular_vbox;
 use vdj_ann::refx::RefData;
 
 pub fn populate_features(

--- a/enclone_main/src/sec_mem.rs
+++ b/enclone_main/src/sec_mem.rs
@@ -1,9 +1,9 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use enclone_core::defs::*;
-use io_utils::*;
+use enclone_core::defs::EncloneControl;
+use io_utils::path_exists;
 use std::process::Command;
-use vector_utils::*;
+use vector_utils::{bin_member, unique_sort};
 
 pub fn test_sec_mem(ctl: &mut EncloneControl) -> Result<(), String> {
     let is_bcr = !ctl.gen_opt.tcr;

--- a/enclone_main/src/setup.rs
+++ b/enclone_main/src/setup.rs
@@ -3,30 +3,30 @@
 // See README for documentation.
 
 use crate::USING_PAGER;
-use enclone::misc1::*;
-use enclone_args::proc_args::*;
-use enclone_args::proc_args2::*;
-use enclone_core::defs::*;
-use enclone_core::prepare_for_apocalypse::*;
+use enclone::misc1::setup_pager;
+use enclone_args::proc_args::proc_args;
+use enclone_args::proc_args2::is_simple_arg;
+use enclone_core::defs::{get_config, EncloneControl};
+use enclone_core::prepare_for_apocalypse::prepare_for_apocalypse;
 use enclone_core::testlist::TEST_FILES_VERSION;
-use enclone_core::*;
-use enclone_help::help1::*;
-use enclone_help::help2::*;
-use enclone_help::help3::*;
-use enclone_help::help4::*;
-use enclone_help::help5::*;
-use enclone_help::help_utils::*;
-use io_utils::*;
+use enclone_core::{require_readable_file, REMOTE_HOST};
+use enclone_help::help1::help1;
+use enclone_help::help2::help2;
+use enclone_help::help3::help3;
+use enclone_help::help4::help4;
+use enclone_help::help5::help5;
+use enclone_help::help_utils::{HelpDesk, HELP_ALL, PLAIN};
+use io_utils::{open_for_read, path_exists};
 use itertools::Itertools;
-use pretty_trace::*;
+use pretty_trace::{new_thread_message, PrettyTrace};
 use std::env;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::sync::atomic::Ordering::SeqCst;
 use std::time::Instant;
-use string_utils::*;
+use string_utils::{stringme, TextUtils};
 use tilde_expand::tilde_expand;
-use vector_utils::*;
+use vector_utils::erase_if;
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_main/src/some_filters.rs
+++ b/enclone_main/src/some_filters.rs
@@ -1,16 +1,16 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use crate::doublets::*;
-use crate::merge_onesies::*;
-use crate::split_orbits::*;
-use crate::weak_chains::*;
-use enclone_core::defs::*;
-use enclone_print::define_mat::*;
+use crate::doublets::delete_doublets;
+use crate::merge_onesies::merge_onesies;
+use crate::split_orbits::split_orbits;
+use crate::weak_chains::weak_chains;
+use enclone_core::defs::{CloneInfo, EncloneControl, ExactClonotype};
+use enclone_print::define_mat::define_mat;
 use equiv::EquivRel;
 use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::time::Instant;
-use vector_utils::*;
+use vector_utils::{erase_if, next_diff12_3, next_diff1_2};
 
 pub fn some_filters(
     orbits: &mut Vec<Vec<i32>>,

--- a/enclone_main/src/split_orbits.rs
+++ b/enclone_main/src/split_orbits.rs
@@ -1,10 +1,10 @@
 // Copyright (c) 2021 10x Genomics, Inc. All rights reserved.
 
-use enclone_core::defs::*;
-use enclone_print::define_mat::*;
+use enclone_core::defs::{CloneInfo, EncloneControl, ExactClonotype};
+use enclone_print::define_mat::define_mat;
 use equiv::EquivRel;
 use std::collections::HashMap;
-use vector_utils::*;
+use vector_utils::{bin_position, next_diff12_3, unique_sort, VecUtils};
 
 // Check for disjoint orbits.
 

--- a/enclone_main/src/stop.rs
+++ b/enclone_main/src/stop.rs
@@ -1,18 +1,18 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use crate::main_enclone::*;
-use crate::opt_d_val::*;
-use crate::subset::*;
-use enclone_core::defs::*;
-use enclone_print::print_clonotypes::*;
+use crate::main_enclone::{EncloneSetup, EncloneState, MainEncloneOutput};
+use crate::opt_d_val::make_opt_d_val;
+use crate::subset::subset_json;
+use enclone_core::defs::{CloneInfo, ColInfo, ExactClonotype, WALLCLOCK};
+use enclone_print::print_clonotypes::print_clonotypes;
 use enclone_proto::types::DonorReferenceItem;
-use enclone_tail::grouper::*;
+use enclone_tail::grouper::grouper;
 use enclone_tail::tail::tail_code;
-use io_utils::*;
-use perf_stats::*;
-use pretty_trace::*;
+use io_utils::{dir_list, open_for_read, path_exists};
+use perf_stats::{elapsed, peak_mem_usage_gb};
+use pretty_trace::stop_profiling;
 use rayon::prelude::*;
-use stats_utils::*;
+use stats_utils::percent_ratio;
 use std::{
     collections::HashMap,
     env,
@@ -21,7 +21,7 @@ use std::{
     thread, time,
     time::Instant,
 };
-use string_utils::*;
+use string_utils::TextUtils;
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_main/src/stop.rs
+++ b/enclone_main/src/stop.rs
@@ -307,14 +307,13 @@ pub fn main_enclone_stop(mut inter: EncloneIntermediates) -> Result<EncloneState
     let (mut cpu_all_stop, mut cpu_this_stop) = (0, 0);
     if ctl.gen_opt.print_cpu || ctl.gen_opt.print_cpu_info {
         let f = open_for_read!["/proc/stat"];
-        for line in f.lines() {
+        if let Some(line) = f.lines().next() {
             let s = line.unwrap();
             let mut t = s.after("cpu");
             while t.starts_with(' ') {
                 t = t.after(" ");
             }
             cpu_all_stop = t.before(" ").force_usize();
-            break;
         }
         let f = open_for_read![&format!("/proc/{}/stat", std::process::id())];
         for line in f.lines() {

--- a/enclone_main/src/subset.rs
+++ b/enclone_main/src/subset.rs
@@ -2,13 +2,16 @@
 
 // Process the SUBSET_JSON option.
 
-use enclone_core::defs::*;
-use io_utils::*;
+use enclone_core::defs::{EncloneControl, ExactClonotype};
+use io_utils::{
+    fwrite, fwriteln, open_for_write_new, open_maybe_compressed, path_exists,
+    read_vector_entry_from_json,
+};
 use serde_json::Value;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Write};
-use string_utils::*;
-use vector_utils::*;
+use string_utils::{strme, TextUtils};
+use vector_utils::{bin_member, unique_sort};
 
 pub fn subset_json(
     ctl: &EncloneControl,

--- a/enclone_main/src/vars.rs
+++ b/enclone_main/src/vars.rs
@@ -1,11 +1,11 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use enclone_core::defs::*;
+use enclone_core::defs::{EncloneControl, GexInfo};
 use regex::Regex;
 use std::collections::HashMap;
 use std::time::Instant;
-use string_utils::*;
-use vector_utils::*;
+use string_utils::TextUtils;
+use vector_utils::unique_sort;
 
 pub fn match_vars(ctl: &mut EncloneControl, gex_info: &GexInfo) -> Result<(), String> {
     // Find matching features for <regular expression>_g etc.

--- a/enclone_main/src/weak_chains.rs
+++ b/enclone_main/src/weak_chains.rs
@@ -3,11 +3,11 @@
 // Based on the number of cells in each column, decide which exact subclonotypes
 // look like junk.  Preliminary heuristic.
 
-use enclone_core::defs::*;
-use enclone_print::define_mat::*;
+use enclone_core::defs::{CloneInfo, EncloneControl, ExactClonotype};
+use enclone_print::define_mat::define_mat;
 use rayon::prelude::*;
 use std::collections::HashMap;
-use vector_utils::*;
+use vector_utils::{erase_if, next_diff12_3};
 
 pub fn weak_chains(
     orbits: &mut Vec<Vec<i32>>,

--- a/enclone_print/src/build_table_stuff.rs
+++ b/enclone_print/src/build_table_stuff.rs
@@ -1,11 +1,11 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use crate::print_utils1::*;
-use ansi_escape::*;
-use enclone_core::defs::*;
+use crate::print_utils1::insert_position_rows;
+use ansi_escape::bold;
+use enclone_core::defs::{justification, ColInfo, EncloneControl, ExactClonotype};
 use itertools::Itertools;
-use string_utils::*;
-use vector_utils::*;
+use string_utils::{strme, TextUtils};
+use vector_utils::unique_sort;
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_print/src/build_table_stuff.rs
+++ b/enclone_print/src/build_table_stuff.rs
@@ -64,18 +64,16 @@ pub fn build_table_stuff(
             if rsi.chain_descrip[j].contains(&"IGH".to_string())
                 || rsi.chain_descrip[j].contains(&"TRB".to_string())
             {
-                row.push(bold(&format!("{}", rsi.chain_descrip[j])));
+                row.push(bold(&rsi.chain_descrip[j].to_string()));
             } else {
-                row.push(format!("{}", rsi.chain_descrip[j]));
+                row.push(rsi.chain_descrip[j].to_string());
             }
+        } else if rsi.chain_descrip[j].contains(&"IGH".to_string())
+            || rsi.chain_descrip[j].contains(&"TRB".to_string())
+        {
+            row.push(bold(&rsi.chain_descrip[j].before(" ◆ ").to_string()));
         } else {
-            if rsi.chain_descrip[j].contains(&"IGH".to_string())
-                || rsi.chain_descrip[j].contains(&"TRB".to_string())
-            {
-                row.push(bold(&format!("{}", rsi.chain_descrip[j].before(" ◆ "))));
-            } else {
-                row.push(format!("{}", rsi.chain_descrip[j].before(" ◆ ")));
-            }
+            row.push(rsi.chain_descrip[j].before(" ◆ ").to_string());
         }
         for _ in 1..rsi.cvars[j].len() {
             row.push("\\ext".to_string());
@@ -114,16 +112,14 @@ pub fn build_table_stuff(
                 if rsi.chain_descrip[j].after(" ◆ ").contains(" ◆ ") {
                     last = rsi.chain_descrip[j].after(" ◆ ").after(" ◆ ").to_string();
                 }
-                if last.len() == 0 {
+                if last.is_empty() {
                     row.push(String::new());
+                } else if rsi.chain_descrip[j].contains(&"IGH".to_string())
+                    || rsi.chain_descrip[j].contains(&"TRB".to_string())
+                {
+                    row.push(bold(&format!("◆ {}", last)));
                 } else {
-                    if rsi.chain_descrip[j].contains(&"IGH".to_string())
-                        || rsi.chain_descrip[j].contains(&"TRB".to_string())
-                    {
-                        row.push(bold(&format!("◆ {}", last)));
-                    } else {
-                        row.push(format!("◆ {}", last));
-                    }
+                    row.push(format!("◆ {}", last));
                 }
                 for _ in 1..rsi.cvars[j].len() {
                     row.push("\\ext".to_string());
@@ -145,7 +141,7 @@ pub fn build_table_stuff(
 
     // Insert position rows.
 
-    *drows = insert_position_rows(&rsi, &show_aa, &field_types, &vars, &row1);
+    *drows = insert_position_rows(rsi, show_aa, field_types, vars, row1);
     let mut drows2 = drows.clone();
     rows.append(&mut drows2);
 
@@ -155,7 +151,7 @@ pub fn build_table_stuff(
     for cx in 0..cols {
         let show = &show_aa[cx];
         for j in 0..rsi.cvars[cx].len() {
-            if rsi.cvars[cx][j] != "amino".to_string() {
+            if rsi.cvars[cx][j] != *"amino" {
                 if drows.is_empty() {
                     row.push(rsi.cvars[cx][j].to_string());
                 } else {
@@ -298,7 +294,7 @@ pub fn build_table_stuff(
                             let left = (q - 3) / 2;
                             let right = q - left - 4;
                             s += &"═".repeat(left);
-                            s += strme(&t);
+                            s += strme(t);
                             s += &"═".repeat(right);
                         } else if q == 3 {
                             s += strme(&t[0..1]);

--- a/enclone_print/src/define_mat.rs
+++ b/enclone_print/src/define_mat.rs
@@ -1,11 +1,11 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use enclone_core::defs::*;
-use enclone_core::join_one::*;
+use enclone_core::defs::{CloneInfo, EncloneControl, ExactClonotype, PotentialJoin};
+use enclone_core::join_one::join_one;
 use equiv::EquivRel;
 use std::cmp::max;
 use std::collections::HashMap;
-use vector_utils::*;
+use vector_utils::{bin_position, next_diff12_3, next_diff1_3, unique_sort};
 
 // Define an equivalence relation on the chains, introducing connections defined by the
 // raw joins.  Also join where there are identical V..J sequences.

--- a/enclone_print/src/define_mat.rs
+++ b/enclone_print/src/define_mat.rs
@@ -30,19 +30,19 @@ fn joiner(
             let v2 = to_exacts[&u2];
             let m2s = &info[j2].exact_cols;
             for j in 0..2 {
-                let z1 = bin_position(&chains, &(v1, m1s[j]));
-                let z2 = bin_position(&chains, &(v2, m2s[j]));
+                let z1 = bin_position(chains, &(v1, m1s[j]));
+                let z2 = bin_position(chains, &(v2, m2s[j]));
                 e.join(z1, z2);
             }
         }
     }
     let mut i = 0;
     while i < seq_chains.len() {
-        let j = next_diff1_3(&seq_chains, i as i32) as usize;
+        let j = next_diff1_3(seq_chains, i as i32) as usize;
         for k in i + 1..j {
             let (x1, x2) = (&seq_chains[i], &seq_chains[k]);
-            let z1 = bin_position(&chains, &(x1.1, x1.2));
-            let z2 = bin_position(&chains, &(x2.1, x2.2));
+            let z1 = bin_position(chains, &(x1.1, x1.2));
+            let z2 = bin_position(chains, &(x2.1, x2.2));
             e.join(z1, z2);
         }
         i = j;
@@ -78,7 +78,7 @@ pub fn define_mat(
             infos.push(x);
         }
     }
-    infos.sort();
+    infos.sort_unstable();
 
     // Define map of exacts to infos.
 
@@ -149,11 +149,11 @@ pub fn define_mat(
                                 is_bcr,
                                 l1,
                                 l2,
-                                &ctl,
-                                &exact_clonotypes,
-                                &info,
-                                &to_bc,
-                                &sr,
+                                ctl,
+                                exact_clonotypes,
+                                info,
+                                to_bc,
+                                sr,
                                 &mut pot,
                             ) {
                                 extras.push((k1, k2));
@@ -170,7 +170,7 @@ pub fn define_mat(
 
     // Define an initial equivalence relation on the chains, and get orbit representatives.
 
-    let mut e = joiner(&infos, &info, &to_exacts, &raw_joinsx, &chains, &seq_chains);
+    let mut e = joiner(&infos, info, &to_exacts, &raw_joinsx, &chains, &seq_chains);
     let mut r = Vec::<i32>::new();
     e.orbit_reps(&mut r);
 
@@ -197,7 +197,7 @@ pub fn define_mat(
         let q2 = bin_position(&r, &p2) as usize;
         rxi.push((q1, q2, i));
     }
-    rxi.sort();
+    rxi.sort_unstable();
     const MAX_USE: usize = 5; // knob set empirically
     let mut rxir = Vec::<(usize, usize, usize)>::new(); // (heavy orbit, light orbit, info index)
     let mut i = 0;
@@ -227,11 +227,11 @@ pub fn define_mat(
                     is_bcr,
                     i1,
                     i2,
-                    &ctl,
-                    &exact_clonotypes,
-                    &info,
-                    &to_bc,
-                    &sr,
+                    ctl,
+                    exact_clonotypes,
+                    info,
+                    to_bc,
+                    sr,
                     &mut pot,
                 ) {
                     e.join(r[f1.0], r[f2.0]);
@@ -361,11 +361,11 @@ pub fn define_mat(
         chainso.push((chainsp[i].2, chainsp[i].3));
         chainsox.push((chainsp[i].2, chainsp[i].3, i));
     }
-    chainsox.sort();
+    chainsox.sort_unstable();
     for i in 0..r.len() {
         r[i] = chainsox[r[i] as usize].2 as i32;
     }
-    r.sort();
+    r.sort_unstable();
 
     // Create rmap, that sends
     // (index into exact subclonotypes for this clonotype,

--- a/enclone_print/src/filter.rs
+++ b/enclone_print/src/filter.rs
@@ -101,10 +101,10 @@ pub fn survives_filter(
                 if ex.clones[i][0].marked {
                     let li = ex.clones[i][0].dataset_index;
                     let bc = &ex.clones[i][0].barcode;
-                    if gex_info.cell_type[li].contains_key(&bc.clone()) {
-                        if gex_info.cell_type[li][&bc.clone()].starts_with('B') {
-                            marked_b = true;
-                        }
+                    if gex_info.cell_type[li].contains_key(&bc.clone())
+                        && gex_info.cell_type[li][&bc.clone()].starts_with('B')
+                    {
+                        marked_b = true;
                     }
                 }
             }
@@ -117,7 +117,7 @@ pub fn survives_filter(
 
     // Barcode required
 
-    if ctl.clono_filt_opt.barcode.len() > 0 {
+    if !ctl.clono_filt_opt.barcode.is_empty() {
         let mut ok = false;
         for s in exacts.iter() {
             let ex = &exact_clonotypes[*s];
@@ -156,7 +156,7 @@ pub fn survives_filter(
     if ctl.clono_filt_opt.vdup {
         let mut dup = false;
         let mut x = rsi.vids.clone();
-        x.sort();
+        x.sort_unstable();
         let mut i = 0;
         while i < x.len() {
             let j = next_diff(&x, i);
@@ -262,10 +262,10 @@ pub fn survives_filter(
                 if refdata.name[rsi.jids[cx]] == ctl.clono_filt_opt.seg[i][j] {
                     hit = true;
                 }
-                if rsi.cids[cx].is_some() {
-                    if refdata.name[rsi.cids[cx].unwrap()] == ctl.clono_filt_opt.seg[i][j] {
-                        hit = true;
-                    }
+                if rsi.cids[cx].is_some()
+                    && refdata.name[rsi.cids[cx].unwrap()] == ctl.clono_filt_opt.seg[i][j]
+                {
+                    hit = true;
                 }
             }
         }
@@ -293,12 +293,11 @@ pub fn survives_filter(
                 if refdata.id[rsi.jids[cx]] == ctl.clono_filt_opt.segn[i][j].force_i32() {
                     hit = true;
                 }
-                if rsi.cids[cx].is_some() {
-                    if refdata.id[rsi.cids[cx].unwrap()]
+                if rsi.cids[cx].is_some()
+                    && refdata.id[rsi.cids[cx].unwrap()]
                         == ctl.clono_filt_opt.segn[i][j].force_i32()
-                    {
-                        hit = true;
-                    }
+                {
+                    hit = true;
                 }
             }
         }
@@ -352,7 +351,7 @@ pub fn survives_filter(
                 datasets.push(ex.clones[j][0].dataset_index);
             }
         }
-        datasets.sort();
+        datasets.sort_unstable();
         let mut freq = Vec::<(u32, usize)>::new();
         make_freq(&datasets, &mut freq);
         if freq.len() == 1
@@ -393,7 +392,7 @@ pub fn survives_filter(
 
     // Clonotypes having given CDR3 (given by Levenshtein distance pattern).
 
-    if ctl.clono_filt_opt.cdr3_lev.len() > 0 {
+    if !ctl.clono_filt_opt.cdr3_lev.is_empty() {
         let fields = ctl
             .clono_filt_opt
             .cdr3_lev
@@ -452,19 +451,9 @@ pub fn survives_filter(
                     if ex.share[m].left {
                         let mut scores = Vec::<f64>::new();
                         let mut ds = Vec::<Vec<usize>>::new();
-                        opt_d(
-                            &ex,
-                            col,
-                            u,
-                            &rsi,
-                            &refdata,
-                            &dref,
-                            &mut scores,
-                            &mut ds,
-                            &ctl,
-                        );
+                        opt_d(ex, col, u, rsi, refdata, dref, &mut scores, &mut ds, ctl);
                         let mut opt = Vec::new();
-                        if ds.len() > 0 {
+                        if !ds.is_empty() {
                             opt = ds[0].clone();
                         }
                         dvotes.push(opt);
@@ -494,19 +483,9 @@ pub fn survives_filter(
                     if ex.share[m].left {
                         let mut scores = Vec::<f64>::new();
                         let mut ds = Vec::<Vec<usize>>::new();
-                        opt_d(
-                            &ex,
-                            col,
-                            u,
-                            &rsi,
-                            &refdata,
-                            &dref,
-                            &mut scores,
-                            &mut ds,
-                            &ctl,
-                        );
+                        opt_d(ex, col, u, rsi, refdata, dref, &mut scores, &mut ds, ctl);
                         let mut opt = Vec::new();
-                        if ds.len() > 0 {
+                        if !ds.is_empty() {
                             opt = ds[0].clone();
                         }
                         if opt.is_empty() {
@@ -534,19 +513,9 @@ pub fn survives_filter(
                     if ex.share[m].left {
                         let mut scores = Vec::<f64>::new();
                         let mut ds = Vec::<Vec<usize>>::new();
-                        opt_d(
-                            &ex,
-                            col,
-                            u,
-                            &rsi,
-                            &refdata,
-                            &dref,
-                            &mut scores,
-                            &mut ds,
-                            &ctl,
-                        );
+                        opt_d(ex, col, u, rsi, refdata, dref, &mut scores, &mut ds, ctl);
                         let mut opt = Vec::new();
-                        if ds.len() > 0 {
+                        if !ds.is_empty() {
                             opt = ds[0].clone();
                         }
                         if opt.len() == 2 {
@@ -563,5 +532,5 @@ pub fn survives_filter(
 
     // Done.
 
-    return true;
+    true
 }

--- a/enclone_print/src/filter.rs
+++ b/enclone_print/src/filter.rs
@@ -4,16 +4,16 @@
 // See also enclone_core src for a list of these filters and
 // the related struct.
 
-use vdj_ann::*;
+use vdj_ann::refx;
 
-use self::refx::*;
+use self::refx::RefData;
 use edit_distance::edit_distance;
-use enclone_core::defs::*;
-use enclone_core::opt_d::*;
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype, GexInfo};
+use enclone_core::opt_d::opt_d;
 use enclone_proto::types::DonorReferenceItem;
-use std::cmp::*;
-use string_utils::*;
-use vector_utils::*;
+use std::cmp::{max, min};
+use string_utils::TextUtils;
+use vector_utils::{make_freq, next_diff, unique_sort};
 
 pub fn survives_filter(
     exacts: &Vec<usize>,

--- a/enclone_print/src/finish_table.rs
+++ b/enclone_print/src/finish_table.rs
@@ -1,15 +1,15 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use crate::build_table_stuff::*;
-use crate::print_utils1::*;
-use crate::print_utils3::*;
-use crate::print_utils5::*;
-use enclone_core::defs::*;
-use enclone_proto::types::*;
+use crate::build_table_stuff::build_table_stuff;
+use crate::print_utils1::make_table;
+use crate::print_utils3::{add_header_text, insert_reference_rows};
+use crate::print_utils5::{build_diff_row, insert_consensus_row};
+use enclone_core::defs::{justification, ColInfo, EncloneControl, ExactClonotype};
+use enclone_proto::types::DonorReferenceItem;
 use std::collections::HashMap;
-use string_utils::*;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use string_utils::TextUtils;
+use vdj_ann::refx::RefData;
+use vector_utils::bin_member;
 
 pub fn finish_table(
     n: usize,

--- a/enclone_print/src/finish_table.rs
+++ b/enclone_print/src/finish_table.rs
@@ -37,7 +37,7 @@ pub fn finish_table(
     // Fill in exact_subclonotype_id, reorder.
 
     let nexacts = exacts.len();
-    if ctl.parseable_opt.pout.len() > 0 || !extra_args.is_empty() {
+    if !ctl.parseable_opt.pout.is_empty() || !extra_args.is_empty() {
         for u in 0..nexacts {
             macro_rules! speak {
                 ($u:expr, $var:expr, $val:expr) => {
@@ -63,7 +63,7 @@ pub fn finish_table(
     // Add header text to mlog.
 
     let mat = &rsi.mat;
-    add_header_text(&ctl, &exacts, &exact_clonotypes, &rord, &mat, mlog);
+    add_header_text(ctl, exacts, exact_clonotypes, rord, mat, mlog);
 
     // Build table stuff.
 
@@ -72,45 +72,45 @@ pub fn finish_table(
     let mut rows = Vec::<Vec<String>>::new();
     let mut drows = Vec::<Vec<String>>::new();
     build_table_stuff(
-        &ctl,
-        &exacts,
-        &exact_clonotypes,
-        &rsi,
-        &vars,
-        &show_aa,
-        &field_types,
+        ctl,
+        exacts,
+        exact_clonotypes,
+        rsi,
+        vars,
+        show_aa,
+        field_types,
         &mut row1,
         &mut justify,
         &mut drows,
         &mut rows,
-        &lvars,
+        lvars,
     );
 
     // Insert universal and donor reference rows.
 
     insert_reference_rows(
-        &ctl,
-        &rsi,
-        &show_aa,
-        &field_types,
-        &refdata,
-        &dref,
+        ctl,
+        rsi,
+        show_aa,
+        field_types,
+        refdata,
+        dref,
         &row1,
         &mut drows,
         &mut rows,
-        &exacts,
-        &exact_clonotypes,
-        &peer_groups,
+        exacts,
+        exact_clonotypes,
+        peer_groups,
     );
 
     // Insert consensus row.
 
     insert_consensus_row(
-        &ctl,
-        &rsi,
+        ctl,
+        rsi,
         exacts.len(),
-        &field_types,
-        &show_aa,
+        field_types,
+        show_aa,
         &row1,
         &mut rows,
     );
@@ -129,14 +129,14 @@ pub fn finish_table(
     // Build the diff row.
 
     build_diff_row(
-        &ctl,
-        &rsi,
+        ctl,
+        rsi,
         &mut rows,
         &mut drows,
         &row1,
         exacts.len(),
-        &field_types,
-        &show_aa,
+        field_types,
+        show_aa,
     );
 
     // Finish building table content.
@@ -171,12 +171,10 @@ pub fn finish_table(
             }
             if !found {
                 row.push(String::new());
+            } else if !lvars[i].ends_with("_%") {
+                row.push(format!("{}", total.round() as usize));
             } else {
-                if !lvars[i].ends_with("_%") {
-                    row.push(format!("{}", total.round() as usize));
-                } else {
-                    row.push(format!("{:.2}", total));
-                }
+                row.push(format!("{:.2}", total));
             }
         }
         // This is necessary but should not be:
@@ -210,12 +208,10 @@ pub fn finish_table(
             let mean = total / n as f64;
             if !found {
                 row.push(String::new());
+            } else if !lvars[i].ends_with("_%") {
+                row.push(format!("{:.1}", mean));
             } else {
-                if !lvars[i].ends_with("_%") {
-                    row.push(format!("{:.1}", mean));
-                } else {
-                    row.push(format!("{:.2}", mean));
-                }
+                row.push(format!("{:.2}", mean));
             }
         }
         // This is necessary but should not be:
@@ -241,7 +237,7 @@ pub fn finish_table(
             justify.push(justification(&rsi.cvars[cx][m]));
         }
     }
-    make_table(&ctl, &mut rows, &justify, &mlog, logz);
+    make_table(ctl, &mut rows, &justify, mlog, logz);
 
     // Add phylogeny.
 

--- a/enclone_print/src/gene_scan.rs
+++ b/enclone_print/src/gene_scan.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use enclone_core::defs::*;
-use string_utils::*;
+use enclone_core::defs::EncloneControl;
+use string_utils::TextUtils;
 
 pub fn gene_scan_test(
     ctl: &EncloneControl,

--- a/enclone_print/src/loupe.rs
+++ b/enclone_print/src/loupe.rs
@@ -5,17 +5,21 @@
 
 use enclone_proto::proto_io::write_proto;
 use enclone_proto::PROTO_VERSION;
-use vdj_ann::*;
+use vdj_ann::refx;
 
-use self::refx::*;
-use amino::*;
-use bio_edit::alignment::pairwise::*;
+use self::refx::RefData;
+use amino::codon_to_aa;
+use bio_edit::alignment::pairwise::Aligner;
 
-use debruijn::dna_string::*;
-use enclone_core::defs::*;
-use enclone_proto::types::*;
-use io_utils::*;
-use vector_utils::*;
+use debruijn::dna_string::DnaString;
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype};
+use enclone_proto::types::{
+    Alignment, Clonotype, ClonotypeChain, DonorReference, DonorReferenceItem, EncloneOutputs,
+    ExactSubClonotype, ExactSubClonotypeChain, ExactSubClonotypeChainInfo,
+    InvariantTCellAnnotation, Metadata, Region, UniversalReference, UniversalReferenceItem,
+};
+use io_utils::write_obj;
+use vector_utils::next_diff12_3;
 
 // Export donor reference/inferred alt allele sequences
 pub fn make_donor_refs(

--- a/enclone_print/src/loupe.rs
+++ b/enclone_print/src/loupe.rs
@@ -25,7 +25,7 @@ pub fn make_donor_refs(
     let mut drefs = Vec::<DonorReferenceItem>::new();
     let mut i = 0;
     while i < alt_refs.len() {
-        let j = next_diff12_3(&alt_refs, i as i32) as usize;
+        let j = next_diff12_3(alt_refs, i as i32) as usize;
         for k in i..j {
             let x = &alt_refs[k];
             let donor_id = x.0;
@@ -62,7 +62,7 @@ pub fn make_donor_refs(
                 nt_sequence: alt,
                 universal_aln: Alignment {
                     ref_start: 0,
-                    cigar: cigar,
+                    cigar,
                 },
             });
         }
@@ -74,7 +74,7 @@ pub fn make_donor_refs(
 fn amino_acid(seq: &[u8], start: usize) -> Vec<u8> {
     seq[start..]
         .chunks_exact(3)
-        .map(|codon| codon_to_aa(&codon))
+        .map(|codon| codon_to_aa(codon))
         .collect()
 }
 
@@ -178,20 +178,20 @@ pub fn make_loupe_clonotype(
         let fwr4_end = Some((ex.share[m0].v_start + ex.share[m0].seq.len()) as u32);
 
         xchains.push(ClonotypeChain {
-            nt_sequence: nt_sequence,
-            aa_sequence: aa_sequence,
+            nt_sequence,
+            aa_sequence,
             u_idx: rsi.uids[cx].map(|idx| idx as u32),
             v_idx: rsi.vids[cx] as u32,
             d_idx: rsi.dids[cx].map(|idx| idx as u32),
             j_idx: rsi.jids[cx] as u32,
             c_idx: rsi.cids[cx].map(|idx| idx as u32),
             donor_v_idx: donor_v_idx.map(|idx| idx as u32),
-            donor_j_idx: donor_j_idx,
-            universal_reference: universal_reference,
-            universal_reference_aln: universal_reference_aln,
+            donor_j_idx,
+            universal_reference,
+            universal_reference_aln,
             aa_sequence_universal,
-            donor_reference: donor_reference,
-            donor_reference_aln: donor_reference_aln,
+            donor_reference,
+            donor_reference_aln,
             aa_sequence_donor,
             v_start: ex.share[m0].v_start as u32,
             v_end: ex.share[m0].v_stop as u32,
@@ -199,16 +199,16 @@ pub fn make_loupe_clonotype(
             j_start: ex.share[m0].j_start as u32,
             j_start_ref: ex.share[m0].j_start_ref as u32,
             j_end: ex.share[m0].j_stop as u32,
-            fwr1_start: fwr1_start,
-            cdr1_start: cdr1_start,
-            fwr2_start: fwr2_start,
-            cdr2_start: cdr2_start,
-            fwr3_start: fwr3_start,
+            fwr1_start,
+            cdr1_start,
+            fwr2_start,
+            cdr2_start,
+            fwr3_start,
             cdr3_start: ex.share[m0].v_start as u32 + ex.share[m0].cdr3_start as u32,
             cdr3_end: ex.share[m0].v_start as u32
                 + (ex.share[m0].cdr3_start + 3 * ex.share[m0].cdr3_aa.len()) as u32,
-            fwr4_end: fwr4_end,
-            chain_type: chain_type,
+            fwr4_end,
+            chain_type,
         });
     }
 
@@ -220,7 +220,7 @@ pub fn make_loupe_clonotype(
         let ex = &exact_clonotypes[exacts[j]];
         for cx in 0..cols {
             let m = mat[cx][j];
-            if !m.is_some() {
+            if m.is_none() {
                 chains.push(None);
                 continue;
             }
@@ -279,25 +279,25 @@ pub fn make_loupe_clonotype(
             // Finally, define the ExactClonotypeChain.
 
             chains.push(Some(ExactSubClonotypeChain {
-                nt_sequence: nt_sequence,
-                aa_sequence: aa_sequence,
+                nt_sequence,
+                aa_sequence,
                 v_start: v_start as u32,
                 j_end: j_end as u32,
                 c_region_idx: c_region_idx.map(|idx| idx as u32),
-                fwr1_start: fwr1_start,
-                cdr1_start: cdr1_start,
-                fwr2_start: fwr2_start,
-                cdr2_start: cdr2_start,
-                fwr3_start: fwr3_start,
+                fwr1_start,
+                cdr1_start,
+                fwr2_start,
+                cdr2_start,
+                fwr3_start,
                 cdr3_start: cdr3_start as u32,
                 cdr3_end: cdr3_end as u32,
-                fwr4_end: fwr4_end,
-                umi_counts: umi_counts,
-                read_counts: read_counts,
-                contig_ids: contig_ids,
-                clonotype_consensus_aln: clonotype_consensus_aln,
-                donor_reference_aln: donor_reference_aln,
-                universal_reference_aln: universal_reference_aln,
+                fwr4_end,
+                umi_counts,
+                read_counts,
+                contig_ids,
+                clonotype_consensus_aln,
+                donor_reference_aln,
+                universal_reference_aln,
             }));
         }
         let mut cell_barcodes = Vec::<String>::new();
@@ -327,9 +327,9 @@ pub fn make_loupe_clonotype(
                     })
                 })
                 .collect(),
-            cell_barcodes: cell_barcodes,
-            inkt_evidence: inkt_evidence,
-            mait_evidence: mait_evidence,
+            cell_barcodes,
+            inkt_evidence,
+            mait_evidence,
         });
     }
 
@@ -352,7 +352,7 @@ pub fn loupe_out(
     refdata: &RefData,
     dref: &Vec<DonorReferenceItem>,
 ) {
-    if ctl.gen_opt.binary.len() > 0 || ctl.gen_opt.proto.len() > 0 {
+    if !ctl.gen_opt.binary.is_empty() || !ctl.gen_opt.proto.is_empty() {
         let mut uref = Vec::new();
         for i in 0..refdata.refs.len() {
             uref.push(UniversalReferenceItem {
@@ -371,9 +371,10 @@ pub fn loupe_out(
         }
         let metadata = match &ctl.gen_opt.proto_metadata {
             Some(fname) => serde_json::from_reader(
-                std::fs::File::open(fname).expect(&format!("Error while reading {}", fname)),
+                std::fs::File::open(fname)
+                    .unwrap_or_else(|_| panic!("Error while reading {}", fname)),
             )
-            .expect(&format!("Unable to deserialize Metadata from {}", fname)),
+            .unwrap_or_else(|_| panic!("Unable to deserialize Metadata from {}", fname)),
             None => Metadata::default(),
         };
         let enclone_outputs = EncloneOutputs {
@@ -386,10 +387,10 @@ pub fn loupe_out(
                 items: dref.to_vec(),
             },
         };
-        if ctl.gen_opt.binary.len() > 0 {
+        if !ctl.gen_opt.binary.is_empty() {
             write_obj(&enclone_outputs, &ctl.gen_opt.binary);
         }
-        if ctl.gen_opt.proto.len() > 0 {
+        if !ctl.gen_opt.proto.is_empty() {
             write_proto(enclone_outputs, &ctl.gen_opt.proto).unwrap();
         }
     }

--- a/enclone_print/src/print_clonotypes.rs
+++ b/enclone_print/src/print_clonotypes.rs
@@ -111,7 +111,7 @@ pub fn print_clonotypes(
 
     // Identify certain extra parseable variables.  These arise from parameterizable cvars.
 
-    let extra_parseables = get_extra_parseables(&ctl, &pcols_sort);
+    let mut extra_parseables = get_extra_parseables(ctl, pcols_sort);
 
     // Compute all_vars.
 
@@ -129,7 +129,7 @@ pub fn print_clonotypes(
             all_vars.push(var.to_string());
         }
     }
-    all_vars.append(&mut extra_parseables.clone());
+    all_vars.append(&mut extra_parseables);
     for x in extra_args.iter() {
         if !rsi_vars.contains(&x) {
             all_vars.push(x.clone());

--- a/enclone_print/src/print_clonotypes.rs
+++ b/enclone_print/src/print_clonotypes.rs
@@ -5,29 +5,29 @@
 //
 // Problem: stack traces from this file consistently do not go back to the main program.
 
-use crate::define_mat::*;
-use crate::filter::*;
-use crate::finish_table::*;
-use crate::gene_scan::*;
-use crate::loupe::*;
-use crate::print_utils1::*;
-use crate::print_utils2::*;
-use crate::print_utils3::*;
-use crate::print_utils4::*;
-use crate::print_utils5::*;
+use crate::define_mat::define_mat;
+use crate::filter::survives_filter;
+use crate::finish_table::finish_table;
+use crate::gene_scan::gene_scan_test;
+use crate::loupe::{loupe_out, make_loupe_clonotype};
+use crate::print_utils1::{compute_field_types, extra_args, start_gen};
+use crate::print_utils2::row_fill;
+use crate::print_utils3::{define_column_info, get_extra_parseables, process_complete};
+use crate::print_utils4::{build_show_aa, compute_bu, compute_some_stats};
+use crate::print_utils5::{delete_weaks, vars_and_shares};
 use enclone_args::proc_args_check::involves_gex_fb;
-use enclone_core::allowed_vars::*;
-use enclone_core::defs::*;
-use enclone_core::mammalian_fixed_len::*;
-use enclone_core::set_speakers::*;
-use enclone_proto::types::*;
+use enclone_core::allowed_vars::{CVARS_ALLOWED, CVARS_ALLOWED_PCELL, LVARS_ALLOWED};
+use enclone_core::defs::{CloneInfo, ColInfo, EncloneControl, ExactClonotype, GexInfo};
+use enclone_core::mammalian_fixed_len::mammalian_fixed_len_peer_groups;
+use enclone_core::set_speakers::set_speakers;
+use enclone_proto::types::{Clonotype, DonorReferenceItem};
 use equiv::EquivRel;
 use rayon::prelude::*;
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
-use string_utils::*;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use string_utils::TextUtils;
+use vdj_ann::refx::RefData;
+use vector_utils::{bin_member, bin_position, erase_if, next_diff12_3, unique_sort};
 
 // Print clonotypes.  A key challenge here is to define the columns that represent shared
 // chains.  This is given below by the code that forms an equivalence relation on the CDR3_AAs.

--- a/enclone_print/src/print_clonotypes.rs
+++ b/enclone_print/src/print_clonotypes.rs
@@ -71,14 +71,14 @@ pub fn print_clonotypes(
 
     // Compute extra args.
 
-    let extra_args = extra_args(&ctl);
+    let extra_args = extra_args(ctl);
 
     // Determine if any lvars need gex info.
 
     let mut need_gex = false;
     {
         let mut all_lvars = lvars.clone();
-        if ctl.parseable_opt.pout.len() == 0 {
+        if ctl.parseable_opt.pout.is_empty() {
         } else if ctl.parseable_opt.pcols.is_empty() {
             for i in 0..LVARS_ALLOWED.len() {
                 all_lvars.push(LVARS_ALLOWED[i].to_string());
@@ -106,7 +106,7 @@ pub fn print_clonotypes(
     for i in 0..rsi.len() {
         max_chains = max(max_chains, rsi[i].mat.len());
     }
-    set_speakers(&ctl, &mut parseable_fields, max_chains);
+    set_speakers(ctl, &mut parseable_fields, max_chains);
     let pcols_sort = &ctl.parseable_opt.pcols_sort;
 
     // Identify certain extra parseable variables.  These arise from parameterizable cvars.
@@ -131,7 +131,7 @@ pub fn print_clonotypes(
     }
     all_vars.append(&mut extra_parseables);
     for x in extra_args.iter() {
-        if !rsi_vars.contains(&x) {
+        if !rsi_vars.contains(x) {
             all_vars.push(x.clone());
         }
     }
@@ -147,7 +147,7 @@ pub fn print_clonotypes(
 
     let mut have_gex = false;
     for i in 0..ctl.origin_info.gex_path.len() {
-        if ctl.origin_info.gex_path[i].len() > 0 {
+        if !ctl.origin_info.gex_path[i].is_empty() {
             have_gex = true;
         }
     }
@@ -168,7 +168,7 @@ pub fn print_clonotypes(
     for li in 0..ctl.origin_info.n() {
         let mut n = 0;
         for y in gex_info.pca[li].iter() {
-            if bin_member(&vdj_cells[li], &y.0) {
+            if bin_member(&vdj_cells[li], y.0) {
                 n += 1;
             }
         }
@@ -177,7 +177,7 @@ pub fn print_clonotypes(
 
     // Compute peer groups.
 
-    let peer_groups = mammalian_fixed_len_peer_groups(&refdata);
+    let peer_groups = mammalian_fixed_len_peer_groups(refdata);
 
     // Traverse the orbits.
 
@@ -244,7 +244,7 @@ pub fn print_clonotypes(
         let loupe_clonotypes = &mut res.6;
         while j < od.len() {
             let k = next_diff12_3(&od, j as i32) as usize;
-            let mut mult = 0 as usize;
+            let mut mult = 0_usize;
             for l in j..k {
                 let x: &CloneInfo = &info[od[l].2 as usize];
                 let m = x.clonotype_index;
@@ -271,14 +271,14 @@ pub fn print_clonotypes(
 
             let mat = define_mat(
                 is_bcr,
-                &to_bc,
-                &sr,
-                &ctl,
-                &exact_clonotypes,
+                to_bc,
+                sr,
+                ctl,
+                exact_clonotypes,
                 &exacts,
                 &od,
-                &info,
-                &raw_joins,
+                info,
+                raw_joins,
             );
             let mut priority = Vec::<(Vec<bool>, usize, usize)>::new();
             for u in 0..exacts.len() {
@@ -315,17 +315,17 @@ pub fn print_clonotypes(
             let nexacts = exacts.len();
             let mat = define_mat(
                 is_bcr,
-                &to_bc,
-                &sr,
-                &ctl,
-                &exact_clonotypes,
+                to_bc,
+                sr,
+                ctl,
+                exact_clonotypes,
                 &exacts,
                 &od,
-                &info,
-                &raw_joins,
+                info,
+                raw_joins,
             );
             let cols = mat.len();
-            let mut rsi = define_column_info(&ctl, &exacts, &exact_clonotypes, &mat, &refdata);
+            let mut rsi = define_column_info(ctl, &exacts, exact_clonotypes, &mat, refdata);
             rsi.mat = mat;
             let mat = &rsi.mat;
 
@@ -340,11 +340,11 @@ pub fn print_clonotypes(
                 && !survives_filter(
                     &exacts,
                     &rsi,
-                    &ctl,
-                    &exact_clonotypes,
-                    &refdata,
-                    &gex_info,
-                    &dref,
+                    ctl,
+                    exact_clonotypes,
+                    refdata,
+                    gex_info,
+                    dref,
                 )
             {
                 if ctl.clono_group_opt.asymmetric_center == "from_filters" {
@@ -356,13 +356,13 @@ pub fn print_clonotypes(
 
             // Generate Loupe data.
 
-            if (ctl.gen_opt.binary.len() > 0 || ctl.gen_opt.proto.len() > 0) && pass == 2 {
+            if (!ctl.gen_opt.binary.is_empty() || !ctl.gen_opt.proto.is_empty()) && pass == 2 {
                 loupe_clonotypes.push(make_loupe_clonotype(
-                    &exact_clonotypes,
+                    exact_clonotypes,
                     &exacts,
                     &rsi,
-                    &refdata,
-                    &dref,
+                    refdata,
+                    dref,
                 ));
             }
 
@@ -384,9 +384,9 @@ pub fn print_clonotypes(
 
                 if pass == 2 {
                     start_gen(
-                        &ctl,
+                        ctl,
                         &exacts,
-                        &exact_clonotypes,
+                        exact_clonotypes,
                         &mut out_data,
                         &mut mlog,
                         &extra_args,
@@ -400,12 +400,12 @@ pub fn print_clonotypes(
                 let mut shares_amino = Vec::<Vec<usize>>::new();
                 vars_and_shares(
                     pass,
-                    &ctl,
+                    ctl,
                     &exacts,
-                    &exact_clonotypes,
+                    exact_clonotypes,
                     &rsi,
-                    &refdata,
-                    &dref,
+                    refdata,
+                    dref,
                     &mut vars,
                     &mut vars_amino,
                     &mut shares_amino,
@@ -416,12 +416,12 @@ pub fn print_clonotypes(
 
                 if pass == 1 {
                     delete_weaks(
-                        &ctl,
+                        ctl,
                         &exacts,
-                        &exact_clonotypes,
+                        exact_clonotypes,
                         total_cells,
-                        &mat,
-                        &refdata,
+                        mat,
+                        refdata,
                         &vars,
                         &mut bads,
                         &mut res.11,
@@ -430,26 +430,26 @@ pub fn print_clonotypes(
 
                 // Done unless on second pass.  Unless there are bounds or COMPLETE specified.
 
-                if pass == 1 && ctl.clono_filt_opt.bounds.len() == 0 && !ctl.gen_opt.complete {
+                if pass == 1 && ctl.clono_filt_opt.bounds.is_empty() && !ctl.gen_opt.complete {
                     continue;
                 }
 
                 // Define amino acid positions to show.
 
                 let show_aa = build_show_aa(
-                    &ctl,
+                    ctl,
                     &rsi,
                     &vars_amino,
                     &shares_amino,
-                    &refdata,
-                    &dref,
+                    refdata,
+                    dref,
                     &exacts,
-                    &exact_clonotypes,
+                    exact_clonotypes,
                 );
 
                 // Define field types corresponding to the amino acid positions to show.
 
-                let field_types = compute_field_types(&ctl, &rsi, &show_aa);
+                let field_types = compute_field_types(ctl, &rsi, &show_aa);
 
                 // Build varmat.
 
@@ -482,7 +482,7 @@ pub fn print_clonotypes(
                             lvarsc.push(lvars[m].clone());
                         }
                         let k = x.after("nd").force_usize();
-                        let mut n = vec![0 as usize; ctl.origin_info.n()];
+                        let mut n = vec![0_usize; ctl.origin_info.n()];
                         for u in 0..nexacts {
                             let ex = &exact_clonotypes[exacts[u]];
                             for l in 0..ex.ncells() {
@@ -591,12 +591,12 @@ pub fn print_clonotypes(
                 let mut ppe = Vec::<Vec<String>>::new();
                 let mut npe = Vec::<Vec<String>>::new();
                 compute_some_stats(
-                    &ctl,
+                    ctl,
                     &lvars,
                     &exacts,
-                    &exact_clonotypes,
-                    &gex_info,
-                    &vdj_cells,
+                    exact_clonotypes,
+                    gex_info,
+                    vdj_cells,
                     &n_vdj_gex,
                     &mut cred,
                     &mut pe,
@@ -634,12 +634,12 @@ pub fn print_clonotypes(
                     let resx = row_fill(
                         pass,
                         u,
-                        &ctl,
+                        ctl,
                         &exacts,
                         &mults,
-                        &exact_clonotypes,
-                        &gex_info,
-                        &refdata,
+                        exact_clonotypes,
+                        gex_info,
+                        refdata,
                         &varmat,
                         &fp,
                         &vars_amino,
@@ -653,13 +653,13 @@ pub fn print_clonotypes(
                         &mut d_all,
                         &mut ind_all,
                         &rsi,
-                        &dref,
+                        dref,
                         &groups,
-                        &d_readers,
-                        &ind_readers,
-                        &h5_data,
+                        d_readers,
+                        ind_readers,
+                        h5_data,
                         &mut these_stats,
-                        &vdj_cells,
+                        vdj_cells,
                         &n_vdj_gex,
                         &lvars,
                         &lvarsh,
@@ -668,7 +668,7 @@ pub fn print_clonotypes(
                         &extra_args,
                         &all_vars,
                         need_gex,
-                        &fate,
+                        fate,
                     );
                     stats.append(&mut these_stats.clone());
                     these_stats.sort_by(|a, b| a.0.cmp(&b.0));
@@ -706,18 +706,18 @@ pub fn print_clonotypes(
                         cell_count,
                         &exacts,
                         &lvars,
-                        &ctl,
+                        ctl,
                         &bli,
-                        &ex,
-                        &exact_clonotypes,
+                        ex,
+                        exact_clonotypes,
                         &mut row,
                         &mut subrows,
                         &varmat,
                         have_gex,
-                        &gex_info,
+                        gex_info,
                         &rsi,
                         &mut sr,
-                        &fate,
+                        fate,
                         &nd_fields,
                         &alt_bcs,
                         &cred,
@@ -726,7 +726,7 @@ pub fn print_clonotypes(
                         &npe,
                         &d_all,
                         &ind_all,
-                        &mat,
+                        mat,
                         &these_stats,
                     );
                     cell_count += ex.clones.len();
@@ -789,9 +789,9 @@ pub fn print_clonotypes(
                                 break;
                             }
                         }
-                        let mut min = 1000_000_000.0_f64;
+                        let mut min = 1_000_000_000.0_f64;
                         let mut mean = 0.0;
-                        let mut max = -1000_000_000.0_f64;
+                        let mut max = -1_000_000_000.0_f64;
                         let mut count = 0;
                         for j in 0..vals.len() {
                             if !vals[j].is_nan() {
@@ -842,7 +842,7 @@ pub fn print_clonotypes(
 
                 // Process COMPLETE.
 
-                process_complete(&ctl, nexacts, &mut bads, &mat);
+                process_complete(ctl, nexacts, &mut bads, mat);
 
                 // Done unless on second pass.
 
@@ -853,7 +853,7 @@ pub fn print_clonotypes(
                 // See if we're in the test and control sets for gene scan.
 
                 gene_scan_test(
-                    &ctl,
+                    ctl,
                     &stats,
                     &stats_orig,
                     nexacts,
@@ -867,23 +867,23 @@ pub fn print_clonotypes(
                 let mut logz = String::new();
                 finish_table(
                     n,
-                    &ctl,
+                    ctl,
                     &exacts,
-                    &exact_clonotypes,
+                    exact_clonotypes,
                     &rsi,
                     &vars,
                     &show_aa,
                     &field_types,
                     &lvars,
-                    &refdata,
-                    &dref,
+                    refdata,
+                    dref,
                     &peer_groups,
                     &mut mlog,
                     &mut logz,
                     &stats,
                     &mut sr,
                     &extra_args,
-                    &pcols_sort,
+                    pcols_sort,
                     &mut out_data,
                     &rord,
                     pass,
@@ -904,7 +904,7 @@ pub fn print_clonotypes(
         }
     });
     for i in 0..results.len() {
-        if results[i].13.len() > 0 {
+        if !results[i].13.is_empty() {
             return Err(results[i].13.clone());
         }
     }
@@ -925,7 +925,7 @@ pub fn print_clonotypes(
     for i in 0..results.len() {
         all_loupe_clonotypes.append(&mut results[i].6);
     }
-    loupe_out(&ctl, all_loupe_clonotypes, &refdata, &dref);
+    loupe_out(ctl, all_loupe_clonotypes, refdata, dref);
 
     // Set up to group and print clonotypes.
 

--- a/enclone_print/src/print_utils1.rs
+++ b/enclone_print/src/print_utils1.rs
@@ -1,18 +1,20 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use amino::*;
-use ansi_escape::*;
-use enclone_core::cell_color::*;
-use enclone_core::defs::*;
-use enclone_core::print_tools::*;
-use io_utils::*;
-use itertools::*;
+use amino::codon_to_aa;
+use ansi_escape::{
+    emit_bold_escape, emit_eight_bit_color_escape, emit_end_escape, emit_red_escape,
+};
+use enclone_core::cell_color::CellColor;
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype, GexInfo, POUT_SEP};
+use enclone_core::print_tools::{color_by_property, emit_codon_color_escape};
+use io_utils::{fwrite, fwriteln};
+use itertools::Itertools;
 use std::cmp::max;
 use std::collections::HashMap;
 use std::io::Write;
-use string_utils::*;
-use tables::*;
-use vector_utils::*;
+use string_utils::stringme;
+use tables::{print_tabular_vbox, visible_width};
+use vector_utils::{bin_member, lower_bound1_3, meet_size, unique_sort, upper_bound1_3, VecUtils};
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_print/src/print_utils1.rs
+++ b/enclone_print/src/print_utils1.rs
@@ -24,7 +24,7 @@ pub fn compute_field_types(
     let cols = rsi.mat.len();
     let mut field_types = vec![Vec::new(); cols];
     for cx in 0..cols {
-        let mut ft = vec![0 as u8; show_aa[cx].len()];
+        let mut ft = vec![0_u8; show_aa[cx].len()];
         let cs1 = rsi.cdr1_starts[cx];
         let cs2 = rsi.cdr2_starts[cx];
         let cs3 = rsi.cdr3_starts[cx];
@@ -110,11 +110,11 @@ pub fn make_table(
 
     // Make table.
 
-    let log0 = stringme(&mlog);
+    let log0 = stringme(mlog);
     let mut log = String::new();
     if ctl.debug_table_printing {
         for i in 0..rows.len() {
-            println!("");
+            println!();
             for j in 0..rows[i].len() {
                 println!(
                     "row = {}, col = {}, entry = {}, vis width = {}",
@@ -125,16 +125,9 @@ pub fn make_table(
                 );
             }
         }
-        println!("");
+        println!();
     }
-    print_tabular_vbox(
-        &mut log,
-        &rows,
-        2,
-        &justify,
-        ctl.debug_table_printing,
-        false,
-    );
+    print_tabular_vbox(&mut log, rows, 2, justify, ctl.debug_table_printing, false);
     if ctl.debug_table_printing {
         println!("{}", log);
     }
@@ -215,7 +208,7 @@ pub fn make_table(
         // Do similar things for header line, but bold the line instead.
         } else if c == '#' {
             if ctl.pretty {
-                *logz += &format!("[01m#");
+                *logz += &"[01m#".to_string();
                 header = true;
             } else {
                 logz.push('#');
@@ -229,7 +222,7 @@ pub fn make_table(
         // In a header line, hop around │ symbols, which should not be colorized.
         } else if header && c == '│' && x[j + 1] != '\n' {
             *logz += "[0m│";
-            *logz += &format!("[01m");
+            *logz += &"[01m".to_string();
         } else if header && c == '│' && x[j + 1] == '\n' {
             *logz += "[0m│";
             header = false;
@@ -257,22 +250,20 @@ pub fn print_digit(p: usize, i: usize, digits: usize, ds: &mut String) {
         } else {
             *ds += &format!("{}", p % 10);
         }
-    } else {
-        if i == 0 {
-            if p >= 100 {
-                *ds += &format!("{}", p / 100);
-            } else {
-                ds.push(' ');
-            }
-        } else if i == 1 {
-            if p >= 10 {
-                *ds += &format!("{}", (p % 100) / 10);
-            } else {
-                ds.push(' ');
-            }
+    } else if i == 0 {
+        if p >= 100 {
+            *ds += &format!("{}", p / 100);
         } else {
-            *ds += &format!("{}", p % 10);
+            ds.push(' ');
         }
+    } else if i == 1 {
+        if p >= 10 {
+            *ds += &format!("{}", (p % 100) / 10);
+        } else {
+            ds.push(' ');
+        }
+    } else {
+        *ds += &format!("{}", p % 10);
     }
 }
 
@@ -320,7 +311,7 @@ pub fn start_gen(
     for u in 0..nexacts {
         n += exact_clonotypes[exacts[u]].ncells();
     }
-    if ctl.parseable_opt.pout.len() > 0 || extra_args.len() > 0 {
+    if !ctl.parseable_opt.pout.is_empty() || !extra_args.is_empty() {
         *out_data = vec![HashMap::<String, String>::new(); nexacts];
     }
     for u in 0..exacts.len() {
@@ -331,7 +322,7 @@ pub fn start_gen(
         bc.sort();
         speak!(u, "barcodes", format!("{}", bc.iter().format(",")));
         for d in ctl.origin_info.dataset_list.iter() {
-            if d.len() > 0 {
+            if !d.is_empty() {
                 let mut bc = Vec::<String>::new();
                 for i in 0..exact_clonotypes[exacts[u]].clones.len() {
                     let q = &exact_clonotypes[exacts[u]].clones[i];
@@ -353,7 +344,7 @@ pub fn start_gen(
             }
             speak!(u, "barcode", format!("{}", bc.iter().format(POUT_SEP)));
             for d in ctl.origin_info.dataset_list.iter() {
-                if d.len() > 0 {
+                if !d.is_empty() {
                     let mut bc = Vec::<String>::new();
                     for i in 0..exact_clonotypes[exacts[u]].clones.len() {
                         let q = &exact_clonotypes[exacts[u]].clones[i];
@@ -381,7 +372,7 @@ pub fn start_gen(
         for m in 0..ex.clones.len() {
             if ex.clones[m][0].donor_index.is_some() {
                 let d = ex.clones[m][0].donor_index.unwrap();
-                if ctl.origin_info.donor_list[d].len() > 0 {
+                if !ctl.origin_info.donor_list[d].is_empty() {
                     donors.push(d);
                 }
             }
@@ -414,12 +405,12 @@ pub fn start_gen(
             for u in 0..nexacts {
                 let ex = &exact_clonotypes[exacts[u]];
                 for l in 0..ex.clones.len() {
-                    if ex.clones[l][0].donor_index.is_some() {
-                        if ex.clones[l][0].donor_index.unwrap() == donors[i] {
-                            datasets.push(
-                                ctl.origin_info.dataset_id[ex.clones[l][0].dataset_index].clone(),
-                            );
-                        }
+                    if ex.clones[l][0].donor_index.is_some()
+                        && ex.clones[l][0].donor_index.unwrap() == donors[i]
+                    {
+                        datasets.push(
+                            ctl.origin_info.dataset_id[ex.clones[l][0].dataset_index].clone(),
+                        );
                     }
                 }
             }
@@ -468,18 +459,18 @@ pub fn insert_position_rows(
         for cx in 0..cols {
             for m in 0..rsi.cvars[cx].len() {
                 if zpass == 1 {
-                    if rsi.cvars[cx][m] == "amino".to_string() {
+                    if rsi.cvars[cx][m] == *"amino" {
                         for p in show_aa[cx].iter() {
                             digits = max(digits, ndigits(*p));
                         }
-                    } else if rsi.cvars[cx][m] == "var".to_string() {
+                    } else if rsi.cvars[cx][m] == *"var" {
                         for p in vars[cx].iter() {
                             digits = max(digits, ndigits(*p));
                         }
                     }
                 } else {
                     for i in 0..digits {
-                        if rsi.cvars[cx][m] == "amino".to_string() {
+                        if rsi.cvars[cx][m] == *"amino" {
                             let mut ds = String::new();
                             for (j, p) in show_aa[cx].iter().enumerate() {
                                 if j > 0 && field_types[cx][j] != field_types[cx][j - 1] {
@@ -488,7 +479,7 @@ pub fn insert_position_rows(
                                 print_digit(*p, i, digits, &mut ds);
                             }
                             drows[i].push(ds);
-                        } else if rsi.cvars[cx][m] == "var".to_string() {
+                        } else if rsi.cvars[cx][m] == *"var" {
                             let mut ds = String::new();
                             for p in vars[cx].iter() {
                                 print_digit(*p, i, digits, &mut ds);
@@ -517,15 +508,15 @@ pub fn color_codon(
 ) -> Vec<u8> {
     let mut log = Vec::<u8>::new();
     let codon = &seq_amino[3 * p..3 * p + 3];
-    let aa = codon_to_aa(&codon);
-    if ctl.gen_opt.color == "codon".to_string() {
-        emit_codon_color_escape(&codon, &mut log);
+    let aa = codon_to_aa(codon);
+    if ctl.gen_opt.color == *"codon" {
+        emit_codon_color_escape(codon, &mut log);
         log.push(aa);
         emit_end_escape(&mut log);
-    } else if ctl.gen_opt.color == "property".to_string() {
-        color_by_property(&vec![aa], &mut log);
+    } else if ctl.gen_opt.color == *"property" {
+        color_by_property(&[aa], &mut log);
     } else {
-        let (low, high) = (lower_bound1_3(&x, &p), upper_bound1_3(&x, &p));
+        let (low, high) = (lower_bound1_3(x, &p), upper_bound1_3(x, &p));
         let (mut total, mut this) = (0.0, 0.0);
         for u in low..high {
             total += x[u as usize].2 as f64;
@@ -542,17 +533,17 @@ pub fn color_codon(
             }
         }
         if color != *last_color {
-            if color == "black".to_string() {
+            if color == *"black" {
                 emit_end_escape(&mut log);
             } else {
-                if color == "red".to_string() {
+                if color == *"red" {
                     emit_red_escape(&mut log);
                 } else {
                     emit_eight_bit_color_escape(&mut log, 6);
                 }
                 emit_bold_escape(&mut log);
             }
-            *last_color = color.clone();
+            *last_color = color;
         }
         fwrite!(log, "{}", aa as char);
     }
@@ -606,15 +597,13 @@ pub fn cdr3_aa_con(
         unique_sort(&mut vals);
         if vals.solo() {
             c.push(vals[0] as char);
+        } else if style == "x" {
+            c.push('X');
         } else {
-            if style == "x" {
-                c.push('X');
-            } else {
-                for m in classes.iter() {
-                    if meet_size(&vals, &m.1) == vals.len() {
-                        c.push(m.0);
-                        break;
-                    }
+            for m in classes.iter() {
+                if meet_size(&vals, &m.1) == vals.len() {
+                    c.push(m.0);
+                    break;
                 }
             }
         }
@@ -658,7 +647,7 @@ pub fn get_gex_matrix_entry(
 
 pub fn extra_args(ctl: &EncloneControl) -> Vec<String> {
     let mut extra_args = ctl.gen_opt.tree.clone();
-    if ctl.plot_opt.plot_xy_filename.len() > 0 {
+    if !ctl.plot_opt.plot_xy_filename.is_empty() {
         extra_args.push(ctl.plot_opt.plot_xy_xvar.clone());
         extra_args.push(ctl.plot_opt.plot_xy_yvar.clone());
     }

--- a/enclone_print/src/print_utils2.rs
+++ b/enclone_print/src/print_utils2.rs
@@ -82,7 +82,7 @@ pub fn row_fill(
             if pass == 2
                 && ctl.parseable_opt.pout.len() > 0
                 && (ctl.parseable_opt.pchains == "max"
-                    || $col + 1 <= ctl.parseable_opt.pchains.force_usize())
+                    || $col < ctl.parseable_opt.pchains.force_usize())
             {
                 let mut v = $var.clone();
                 v = v.replace("_Σ", "_sum");

--- a/enclone_print/src/print_utils2.rs
+++ b/enclone_print/src/print_utils2.rs
@@ -123,7 +123,7 @@ pub fn row_fill(
 
     let cols = varmat[0].len();
     if ctl.gen_opt.row_fill_verbose {
-        eprintln!("");
+        eprintln!();
     }
 
     // Compute dataset indices, gex, gex_min, gex_max, gex_mean, gex_sum,
@@ -282,13 +282,13 @@ pub fn row_fill(
             }
         }
         count_unsorted = counts.clone();
-        counts.sort();
+        counts.sort_unstable();
         for n in counts.iter() {
             if *n < 100 {
                 *gex_low += 1;
             }
         }
-        if counts.len() > 0 {
+        if !counts.is_empty() {
             gex_median = rounded_median(&counts);
             gex_min = counts[0];
             gex_max = counts[counts.len() - 1];
@@ -299,7 +299,7 @@ pub fn row_fill(
     let entropies_unsorted = entropies.clone();
     entropies.sort_by(|a, b| a.partial_cmp(b).unwrap());
     let mut entropy = 0.0;
-    if entropies.len() > 0 {
+    if !entropies.is_empty() {
         entropy = median_f64(&entropies);
     }
 
@@ -308,7 +308,7 @@ pub fn row_fill(
     // LinearCondition::require_valid_variables.
 
     let mut all_lvars = lvars.clone();
-    if ctl.parseable_opt.pout.len() == 0 {
+    if ctl.parseable_opt.pout.is_empty() {
     } else if ctl.parseable_opt.pcols.is_empty() {
         for i in 0..LVARS_ALLOWED.len() {
             if !lvarsh.contains(&LVARS_ALLOWED[i].to_string()) {
@@ -338,28 +338,28 @@ pub fn row_fill(
         let x = &all_lvars[i];
         if !proc_lvar1(
             i,
-            &x,
+            x,
             pass,
             u,
-            &ctl,
-            &exacts,
-            &mults,
-            &exact_clonotypes,
-            &gex_info,
-            &refdata,
-            &varmat,
-            &fp,
+            ctl,
+            exacts,
+            mults,
+            exact_clonotypes,
+            gex_info,
+            refdata,
+            varmat,
+            fp,
             row,
             out_data,
             d_all,
             ind_all,
-            &rsi,
-            &dref,
-            &groups,
+            rsi,
+            dref,
+            groups,
             stats,
-            &vdj_cells,
-            &n_vdj_gex,
-            &nd_fields,
+            vdj_cells,
+            n_vdj_gex,
+            nd_fields,
             &lvars,
             &lenas,
             &alt_bcs,
@@ -374,33 +374,33 @@ pub fn row_fill(
             entropy,
             &entropies_unsorted,
             &fcounts,
-            &extra_args,
-            &fate,
+            extra_args,
+            fate,
         ) {
             let _ = proc_lvar2(
                 i,
-                &x,
+                x,
                 pass,
                 u,
-                &ctl,
-                &exacts,
-                &mults,
-                &exact_clonotypes,
-                &gex_info,
-                &refdata,
-                &varmat,
-                &fp,
+                ctl,
+                exacts,
+                mults,
+                exact_clonotypes,
+                gex_info,
+                refdata,
+                varmat,
+                fp,
                 row,
                 out_data,
                 d_all,
                 ind_all,
-                &rsi,
-                &dref,
-                &groups,
+                rsi,
+                dref,
+                groups,
                 stats,
-                &vdj_cells,
-                &n_vdj_gex,
-                &nd_fields,
+                vdj_cells,
+                n_vdj_gex,
+                nd_fields,
                 &lvars,
                 &lenas,
                 &alt_bcs,
@@ -415,8 +415,8 @@ pub fn row_fill(
                 entropy,
                 &entropies_unsorted,
                 &fcounts,
-                &extra_args,
-                &fate,
+                extra_args,
+                fate,
             );
         }
     }
@@ -508,12 +508,12 @@ pub fn row_fill(
             let mut needed = false;
             let var = &all_vars[j];
             let varc = format!("{}{}", var, col + 1);
-            if jj < rsi.cvars[col].len() && cvars.contains(&var) {
+            if jj < rsi.cvars[col].len() && cvars.contains(var) {
                 needed = true;
             } else if pass == 2
-                && ctl.parseable_opt.pout.len() > 0
+                && !ctl.parseable_opt.pout.is_empty()
                 && (ctl.parseable_opt.pchains == "max"
-                    || col + 1 <= ctl.parseable_opt.pchains.force_usize())
+                    || col < ctl.parseable_opt.pchains.force_usize())
                 && (pcols_sort.is_empty() || bin_member(&pcols_sort, &varc))
             {
                 needed = true;
@@ -525,7 +525,7 @@ pub fn row_fill(
                 continue;
             }
             let col_var = jj < rsi_vars.len();
-            if !col_var && ctl.parseable_opt.pout.len() == 0 && extra_args.is_empty() {
+            if !col_var && ctl.parseable_opt.pout.is_empty() && extra_args.is_empty() {
                 continue;
             }
 
@@ -588,13 +588,13 @@ pub fn row_fill(
             numis.push(ex.clones[j][mid].umi_count);
             nreads.push(ex.clones[j][mid].read_count);
         }
-        numis.sort();
+        numis.sort_unstable();
         let median_numis = rounded_median(&numis);
         let utot: usize = numis.iter().sum();
         let u_mean = (utot as f64 / numis.len() as f64).round() as usize;
         let u_min = *numis.iter().min().unwrap();
         let u_max = *numis.iter().max().unwrap();
-        nreads.sort();
+        nreads.sort_unstable();
         let rtot: usize = nreads.iter().sum();
         let r_mean = (rtot as f64 / nreads.len() as f64).round() as usize;
         let r_min = *nreads.iter().min().unwrap();
@@ -663,12 +663,12 @@ pub fn row_fill(
                 continue;
             }
             let varc = format!("{}{}", var, col + 1);
-            if jj < rsi.cvars[col].len() && cvars.contains(&var) {
+            if jj < rsi.cvars[col].len() && cvars.contains(var) {
                 needed = true;
             } else if pass == 2
-                && ctl.parseable_opt.pout.len() > 0
+                && !ctl.parseable_opt.pout.is_empty()
                 && (ctl.parseable_opt.pchains == "max"
-                    || col + 1 <= ctl.parseable_opt.pchains.force_usize())
+                    || col < ctl.parseable_opt.pchains.force_usize())
                 && (pcols_sort.is_empty() || bin_member(&pcols_sort, &varc))
             {
                 needed = true;
@@ -686,31 +686,31 @@ pub fn row_fill(
                 continue;
             }
             let col_var = jj < rsi_vars.len();
-            if !col_var && ctl.parseable_opt.pout.len() == 0 && extra_args.is_empty() {
+            if !col_var && ctl.parseable_opt.pout.is_empty() && extra_args.is_empty() {
                 continue;
             }
 
             // Compute.
 
             if !proc_cvar1(
-                &var,
+                var,
                 jj,
                 col,
                 mid,
                 pass,
                 u,
-                &ex,
-                &ctl,
-                &exacts,
-                &exact_clonotypes,
-                &refdata,
-                &varmat,
+                ex,
+                ctl,
+                exacts,
+                exact_clonotypes,
+                refdata,
+                varmat,
                 out_data,
-                &rsi,
-                &dref,
-                &peer_groups,
-                &show_aa,
-                &field_types,
+                rsi,
+                dref,
+                peer_groups,
+                show_aa,
+                field_types,
                 col_var,
                 &pcols_sort,
                 bads,
@@ -725,28 +725,28 @@ pub fn row_fill(
                 r_max,
                 r_mean,
                 rtot,
-                &extra_args,
+                extra_args,
                 stats,
             )? {
                 let _ = proc_cvar2(
-                    &var,
+                    var,
                     jj,
                     col,
                     mid,
                     pass,
                     u,
-                    &ex,
-                    &ctl,
-                    &exacts,
-                    &exact_clonotypes,
-                    &refdata,
-                    &varmat,
+                    ex,
+                    ctl,
+                    exacts,
+                    exact_clonotypes,
+                    refdata,
+                    varmat,
                     out_data,
-                    &rsi,
-                    &dref,
-                    &peer_groups,
-                    &show_aa,
-                    &field_types,
+                    rsi,
+                    dref,
+                    peer_groups,
+                    show_aa,
+                    field_types,
                     col_var,
                     &pcols_sort,
                     bads,
@@ -761,7 +761,7 @@ pub fn row_fill(
                     r_max,
                     r_mean,
                     rtot,
-                    &extra_args,
+                    extra_args,
                     stats,
                 );
             }

--- a/enclone_print/src/print_utils2.rs
+++ b/enclone_print/src/print_utils2.rs
@@ -3,21 +3,21 @@
 // This file contains the single function row_fill,
 // plus a small helper function get_gex_matrix_entry.
 
-use crate::proc_cvar1::*;
-use crate::proc_cvar2::*;
-use crate::proc_lvar1::*;
-use crate::proc_lvar2::*;
-use amino::*;
-use enclone_core::allowed_vars::*;
-use enclone_core::defs::*;
-use enclone_core::median::*;
-use enclone_proto::types::*;
-use itertools::*;
+use crate::proc_cvar1::proc_cvar1;
+use crate::proc_cvar2::proc_cvar2;
+use crate::proc_lvar1::proc_lvar1;
+use crate::proc_lvar2::proc_lvar2;
+use amino::{aa_seq, codon_to_aa};
+use enclone_core::allowed_vars::LVARS_ALLOWED;
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype, GexInfo};
+use enclone_core::median::{median_f64, rounded_median};
+use enclone_proto::types::DonorReferenceItem;
+use itertools::Itertools;
 use ndarray::s;
 use std::collections::{HashMap, HashSet};
-use string_utils::*;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use string_utils::{stringme, strme, TextUtils};
+use vdj_ann::refx::RefData;
+use vector_utils::{bin_member, bin_position, unique_sort};
 
 // The following code creates a row in the enclone output table for a clonotype.  Simultaneously
 // it generates a row of parseable output.  And it does some other things that are not described

--- a/enclone_print/src/print_utils2.rs
+++ b/enclone_print/src/print_utils2.rs
@@ -536,36 +536,18 @@ pub fn row_fill(
             } else if *var == "v_id" {
                 cvar_stats1![j, var, format!("{}", refdata.id[rsi.vids[col]])];
             } else if *var == "d_name" {
-                let mut dname = String::new();
-                if rsi.dids[col].is_some() {
-                    dname = refdata.name[rsi.dids[col].unwrap()].clone();
-                }
+                let dname = if rsi.dids[col].is_some() {
+                    refdata.name[rsi.dids[col].unwrap()].clone()
+                } else {
+                    String::new()
+                };
                 cvar_stats1![j, var, dname];
             } else if *var == "d_id" {
-                let mut did = String::new();
-                if rsi.dids[col].is_some() {
-                    did = format!("{}", refdata.id[rsi.dids[col].unwrap()]);
-                }
-                cvar_stats1![j, var, did];
-            } else if *var == "j_name" {
-                cvar_stats1![j, var, refdata.name[rsi.jids[col]]];
-            } else if *var == "j_id" {
-                cvar_stats1![j, var, format!("{}", refdata.id[rsi.jids[col]])];
-            } else if *var == "v_name" {
-                cvar_stats1![j, var, refdata.name[rsi.vids[col]]];
-            } else if *var == "v_id" {
-                cvar_stats1![j, var, format!("{}", refdata.id[rsi.vids[col]])];
-            } else if *var == "d_name" {
-                let mut dname = String::new();
-                if rsi.dids[col].is_some() {
-                    dname = refdata.name[rsi.dids[col].unwrap()].clone();
-                }
-                cvar_stats1![j, var, dname];
-            } else if *var == "d_id" {
-                let mut did = String::new();
-                if rsi.dids[col].is_some() {
-                    did = format!("{}", refdata.id[rsi.dids[col].unwrap()]);
-                }
+                let did = if rsi.dids[col].is_some() {
+                    format!("{}", refdata.id[rsi.dids[col].unwrap()])
+                } else {
+                    String::new()
+                };
                 cvar_stats1![j, var, did];
             } else if *var == "j_name" {
                 cvar_stats1![j, var, refdata.name[rsi.jids[col]]];

--- a/enclone_print/src/print_utils3.rs
+++ b/enclone_print/src/print_utils3.rs
@@ -46,7 +46,7 @@ pub fn define_column_info(
                 if ex.left {
                     left = true;
                 }
-                if ex.vs_notesx.len() > 0 {
+                if !ex.vs_notesx.is_empty() {
                     have_notes = true;
                 }
             }
@@ -215,12 +215,12 @@ pub fn define_column_info(
                 }
             }
         }
-        u.sort();
-        v.sort();
+        u.sort_unstable();
+        v.sort_unstable();
         vp.sort();
-        d.sort();
-        j.sort();
-        c.sort();
+        d.sort_unstable();
+        j.sort_unstable();
+        c.sort_unstable();
         let mut uf = Vec::<(u32, usize)>::new();
         make_freq(&u, &mut uf);
         if !uf.is_empty() {
@@ -307,27 +307,27 @@ pub fn define_column_info(
     // Return.
 
     ColInfo {
-        left: left,
-        uids: uids,
-        vids: vids,
-        vpids: vpids,
-        dids: dids,
-        jids: jids,
-        cids: cids,
-        fr1_starts: fr1_starts,
-        fr2_starts: fr2_starts,
-        fr3_starts: fr3_starts,
-        cdr1_starts: cdr1_starts,
-        cdr2_starts: cdr2_starts,
-        cdr3_starts: cdr3_starts,
-        cdr3_lens: cdr3_lens,
-        seq_lens: seq_lens,
-        seq_del_lens: seq_del_lens,
-        seqss: seqss,
-        seqss_amino: seqss_amino,
-        chain_descrip: chain_descrip,
+        left,
+        uids,
+        vids,
+        vpids,
+        dids,
+        jids,
+        cids,
+        fr1_starts,
+        fr2_starts,
+        fr3_starts,
+        cdr1_starts,
+        cdr2_starts,
+        cdr3_starts,
+        cdr3_lens,
+        seq_lens,
+        seq_del_lens,
+        seqss,
+        seqss_amino,
+        chain_descrip,
         mat: Vec::<Vec<Option<usize>>>::new(),
-        cvars: cvars,
+        cvars,
     }
 }
 
@@ -413,7 +413,7 @@ pub fn insert_reference_rows(
     peer_groups: &Vec<Vec<(usize, u8, u32)>>,
 ) {
     let cols = rsi.seq_del_lens.len();
-    if drows.len() >= 1 {
+    if !drows.is_empty() {
         for pass in 1..=2 {
             let mut row = Vec::<String>::new();
             if pass == 1 {
@@ -500,7 +500,7 @@ pub fn insert_reference_rows(
                     } else {
                         let x = &peer_groups[rsi.vids[cz]];
                         let last = k == show_aa[cz].len() - 1;
-                        let log = color_codon(&ctl, &refseq, &x, p, &mut last_color, last);
+                        let log = color_codon(ctl, &refseq, x, p, &mut last_color, last);
                         refx += strme(&log);
                     }
                 }

--- a/enclone_print/src/print_utils3.rs
+++ b/enclone_print/src/print_utils3.rs
@@ -1,15 +1,15 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use crate::print_utils1::*;
-use enclone_core::allowed_vars::*;
-use enclone_core::defs::*;
-use enclone_proto::types::*;
-use io_utils::*;
+use crate::print_utils1::color_codon;
+use enclone_core::allowed_vars::{CVARS_ALLOWED, CVARS_ALLOWED_PCELL};
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype};
+use enclone_proto::types::DonorReferenceItem;
+use io_utils::fwriteln;
 use itertools::Itertools;
 use std::io::Write;
-use string_utils::*;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use string_utils::strme;
+use vdj_ann::refx::RefData;
+use vector_utils::{bin_member, erase_if, make_freq, unique_sort};
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_print/src/print_utils4.rs
+++ b/enclone_print/src/print_utils4.rs
@@ -1,15 +1,15 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use crate::print_utils1::*;
-use amino::*;
-use enclone_core::defs::*;
-use enclone_proto::types::*;
+use crate::print_utils1::get_gex_matrix_entry;
+use amino::codon_to_aa;
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype, GexInfo};
+use enclone_proto::types::DonorReferenceItem;
 use equiv::EquivRel;
 use itertools::Itertools;
 use std::collections::HashMap;
-use string_utils::*;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use string_utils::TextUtils;
+use vdj_ann::refx::RefData;
+use vector_utils::{bin_member, bin_position, bin_position1_2, unique_sort};
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_print/src/print_utils4.rs
+++ b/enclone_print/src/print_utils4.rs
@@ -36,24 +36,22 @@ pub fn build_show_aa(
                 }
             }
         }
-        if ctl.clono_print_opt.amino.contains(&"cdr1".to_string()) {
-            if rsi.cdr1_starts[cx].is_some()
-                && rsi.fr2_starts[cx].is_some()
-                && rsi.cdr1_starts[cx].unwrap() <= rsi.fr2_starts[cx].unwrap()
-            {
-                for j in (rsi.cdr1_starts[cx].unwrap()..rsi.fr2_starts[cx].unwrap()).step_by(3) {
-                    show_aa[cx].push(j / 3);
-                }
+        if ctl.clono_print_opt.amino.contains(&"cdr1".to_string())
+            && rsi.cdr1_starts[cx].is_some()
+            && rsi.fr2_starts[cx].is_some()
+            && rsi.cdr1_starts[cx].unwrap() <= rsi.fr2_starts[cx].unwrap()
+        {
+            for j in (rsi.cdr1_starts[cx].unwrap()..rsi.fr2_starts[cx].unwrap()).step_by(3) {
+                show_aa[cx].push(j / 3);
             }
         }
-        if ctl.clono_print_opt.amino.contains(&"cdr2".to_string()) {
-            if rsi.cdr2_starts[cx].is_some()
-                && rsi.fr3_starts[cx].is_some()
-                && rsi.cdr2_starts[cx].unwrap() <= rsi.fr3_starts[cx].unwrap()
-            {
-                for j in (rsi.cdr2_starts[cx].unwrap()..rsi.fr3_starts[cx].unwrap()).step_by(3) {
-                    show_aa[cx].push(j / 3);
-                }
+        if ctl.clono_print_opt.amino.contains(&"cdr2".to_string())
+            && rsi.cdr2_starts[cx].is_some()
+            && rsi.fr3_starts[cx].is_some()
+            && rsi.cdr2_starts[cx].unwrap() <= rsi.fr3_starts[cx].unwrap()
+        {
+            for j in (rsi.cdr2_starts[cx].unwrap()..rsi.fr3_starts[cx].unwrap()).step_by(3) {
+                show_aa[cx].push(j / 3);
             }
         }
         if ctl.clono_print_opt.amino.contains(&"cdr3".to_string()) {
@@ -62,28 +60,29 @@ pub fn build_show_aa(
                 show_aa[cx].push(p);
             }
         }
-        if ctl.clono_print_opt.amino.contains(&"fwr1".to_string()) {
-            if rsi.cdr1_starts[cx].is_some() && rsi.fr1_starts[cx] <= rsi.cdr1_starts[cx].unwrap() {
-                for j in (rsi.fr1_starts[cx]..rsi.cdr1_starts[cx].unwrap()).step_by(3) {
-                    show_aa[cx].push(j / 3);
-                }
+        if ctl.clono_print_opt.amino.contains(&"fwr1".to_string())
+            && rsi.cdr1_starts[cx].is_some()
+            && rsi.fr1_starts[cx] <= rsi.cdr1_starts[cx].unwrap()
+        {
+            for j in (rsi.fr1_starts[cx]..rsi.cdr1_starts[cx].unwrap()).step_by(3) {
+                show_aa[cx].push(j / 3);
             }
         }
-        if ctl.clono_print_opt.amino.contains(&"fwr2".to_string()) {
-            if rsi.fr2_starts[cx].is_some()
-                && rsi.cdr2_starts[cx].is_some()
-                && rsi.fr2_starts[cx].unwrap() <= rsi.cdr2_starts[cx].unwrap()
-            {
-                for j in (rsi.fr2_starts[cx].unwrap()..rsi.cdr2_starts[cx].unwrap()).step_by(3) {
-                    show_aa[cx].push(j / 3);
-                }
+        if ctl.clono_print_opt.amino.contains(&"fwr2".to_string())
+            && rsi.fr2_starts[cx].is_some()
+            && rsi.cdr2_starts[cx].is_some()
+            && rsi.fr2_starts[cx].unwrap() <= rsi.cdr2_starts[cx].unwrap()
+        {
+            for j in (rsi.fr2_starts[cx].unwrap()..rsi.cdr2_starts[cx].unwrap()).step_by(3) {
+                show_aa[cx].push(j / 3);
             }
         }
-        if ctl.clono_print_opt.amino.contains(&"fwr3".to_string()) {
-            if rsi.fr3_starts[cx].is_some() && rsi.fr3_starts[cx].unwrap() <= rsi.cdr3_starts[cx] {
-                for j in (rsi.fr3_starts[cx].unwrap()..rsi.cdr3_starts[cx]).step_by(3) {
-                    show_aa[cx].push(j / 3);
-                }
+        if ctl.clono_print_opt.amino.contains(&"fwr3".to_string())
+            && rsi.fr3_starts[cx].is_some()
+            && rsi.fr3_starts[cx].unwrap() <= rsi.cdr3_starts[cx]
+        {
+            for j in (rsi.fr3_starts[cx].unwrap()..rsi.cdr3_starts[cx]).step_by(3) {
+                show_aa[cx].push(j / 3);
             }
         }
         if ctl.clono_print_opt.amino.contains(&"fwr4".to_string()) {
@@ -237,7 +236,7 @@ pub fn compute_some_stats(
 
     *cred = vec![Vec::<String>::new(); lvars.len()];
     for k in 0..lvars.len() {
-        if lvars[k] == "cred".to_string() {
+        if lvars[k] == *"cred" {
             for u in 0..nexacts {
                 let clonotype_id = exacts[u];
                 let ex = &exact_clonotypes[clonotype_id];
@@ -323,7 +322,7 @@ pub fn compute_some_stats(
             unique_sort(&mut ids);
             let mut reps = Vec::<i32>::new();
             e.orbit_reps(&mut reps);
-            reps.sort();
+            reps.sort_unstable();
             for i in 0..bcs.len() {
                 pe[k][to_index[i]] = format!("{}", bin_position(&ids, &e.class_id(i as i32)));
             }
@@ -496,7 +495,7 @@ pub fn compute_bu(
             let ex = &exact_clonotypes[exacts[u]];
             for k in 0..lvars.len() {
                 let var = lvars[k].clone();
-                let p = bin_position1_2(&these_stats, &var);
+                let p = bin_position1_2(these_stats, &var);
                 let nr = row.len();
                 let mut filled = false;
                 for l in 0..ctl.origin_info.n() {
@@ -522,23 +521,23 @@ pub fn compute_bu(
                 {
                     let stats_me = &these_stats[p as usize].1;
                     row.push(stats_me[bcl.2].clone());
-                } else if var == "n_b".to_string() {
+                } else if var == *"n_b" {
                     let mut n = 0;
                     let li = ex.clones[bcl.2][0].dataset_index;
-                    if gex_info.cell_type[li].contains_key(&bc.clone()) {
-                        if gex_info.cell_type[li][&bc.clone()].starts_with('B') {
-                            n = 1;
-                        }
+                    if gex_info.cell_type[li].contains_key(&bc.clone())
+                        && gex_info.cell_type[li][&bc.clone()].starts_with('B')
+                    {
+                        n = 1;
                     }
                     row.push(format!("{}", n));
-                } else if var == "filter".to_string() {
+                } else if var == *"filter" {
                     let mut f = String::new();
                     if fate[li].contains_key(&bc.clone()) {
                         f = fate[li][&bc.clone()].clone();
                         f = f.between(" ", " ").to_string();
                     }
                     row.push(f);
-                } else if var == "n_other".to_string() {
+                } else if var == *"n_other" {
                     let mut n = 0;
                     let di = ex.clones[bcl.2][0].dataset_index;
                     let f = format!("n_{}", ctl.origin_info.dataset_id[di]);
@@ -552,71 +551,69 @@ pub fn compute_bu(
                         n = 1;
                     }
                     row.push(format!("{}", n));
-                } else if var == "sec".to_string() {
+                } else if var == *"sec" {
                     let mut n = 0;
                     if ctl.origin_info.secmem[li].contains_key(&bc.clone()) {
                         n = ctl.origin_info.secmem[li][&bc.clone()].0;
                     }
                     row.push(format!("{}", n));
-                } else if var == "mem".to_string() {
+                } else if var == *"mem" {
                     let mut n = 0;
                     if ctl.origin_info.secmem[li].contains_key(&bc.clone()) {
                         n = ctl.origin_info.secmem[li][&bc.clone()].1;
                     }
                     row.push(format!("{}", n));
-                } else if bin_member(&alt_bcs, &var) {
+                } else if bin_member(alt_bcs, &var) {
                     let mut val = String::new();
                     let alt = &ctl.origin_info.alt_bc_fields[li];
                     for j in 0..alt.len() {
-                        if alt[j].0 == lvars[k] {
-                            if alt[j].1.contains_key(&bc.clone()) {
-                                val = alt[j].1[&bc.clone()].clone();
-                            }
+                        if alt[j].0 == lvars[k] && alt[j].1.contains_key(&bc.clone()) {
+                            val = alt[j].1[&bc.clone()].clone();
                         }
                     }
                     row.push(val);
-                } else if var == "datasets".to_string() {
-                    row.push(format!("{}", ctl.origin_info.dataset_id[li].clone()));
-                } else if var == "origins".to_string() {
-                    row.push(format!("{}", ctl.origin_info.origin_id[li].clone()));
-                } else if var == "donors".to_string() {
-                    row.push(format!("{}", ctl.origin_info.donor_id[li].clone()));
-                } else if var == "clust".to_string() && have_gex {
+                } else if var == *"datasets" {
+                    row.push(ctl.origin_info.dataset_id[li].clone().to_string());
+                } else if var == *"origins" {
+                    row.push(ctl.origin_info.origin_id[li].clone().to_string());
+                } else if var == *"donors" {
+                    row.push(ctl.origin_info.donor_id[li].clone().to_string());
+                } else if var == *"clust" && have_gex {
                     let mut cid = 0;
                     if gex_info.cluster[li].contains_key(&bc.clone()) {
                         cid = gex_info.cluster[li][&bc.clone()];
                     }
                     row.push(format!("{}", cid));
                 } else if var.starts_with("pe") && have_gex {
-                    row.push(format!("{}", pe[k][cell_count + bcl.2]));
+                    row.push(pe[k][cell_count + bcl.2].to_string());
                 } else if var.starts_with("npe") && have_gex {
-                    row.push(format!("{}", npe[k][cell_count + bcl.2]));
+                    row.push(npe[k][cell_count + bcl.2].to_string());
                 } else if var.starts_with("ppe") && have_gex {
-                    row.push(format!("{}", ppe[k][cell_count + bcl.2]));
-                } else if var == "cred".to_string() && have_gex {
-                    row.push(format!("{}", cred[k][cell_count + bcl.2]));
-                } else if var == "type".to_string() && have_gex {
+                    row.push(ppe[k][cell_count + bcl.2].to_string());
+                } else if var == *"cred" && have_gex {
+                    row.push(cred[k][cell_count + bcl.2].to_string());
+                } else if var == *"type" && have_gex {
                     let mut cell_type = "".to_string();
                     if gex_info.cell_type[li].contains_key(&bc.clone()) {
                         cell_type = gex_info.cell_type[li][&bc.clone()].clone();
                     }
                     row.push(cell_type);
-                } else if var == "n_gex".to_string() && have_gex {
+                } else if var == *"n_gex" && have_gex {
                     let mut n_gex = 0;
-                    if bin_member(&gex_info.gex_cell_barcodes[li], &bc) {
+                    if bin_member(&gex_info.gex_cell_barcodes[li], bc) {
                         n_gex = 1;
                     }
                     row.push(format!("{}", n_gex));
-                } else if var == "mark".to_string() {
+                } else if var == *"mark" {
                     let mut mark = String::new();
                     if ex.clones[bcl.2][0].marked {
                         mark = "x".to_string();
                     }
                     row.push(mark);
-                } else if var == "entropy".to_string() && have_gex {
+                } else if var == *"entropy" && have_gex {
                     // NOTE DUPLICATION WITH CODE BELOW.
                     let mut gex_count = 0;
-                    let p = bin_position(&gex_info.gex_barcodes[li], &bc);
+                    let p = bin_position(&gex_info.gex_barcodes[li], bc);
                     if p >= 0 {
                         let mut raw_count = 0;
                         if gex_info.gex_matrices[li].initialized() {
@@ -666,7 +663,7 @@ pub fn compute_bu(
                     // this calc isn't needed except in _% case below
                     // TODO: ELIMINATE UNNEEDED CALC
                     let mut gex_count = 0.0;
-                    let p = bin_position(&gex_info.gex_barcodes[li], &bc);
+                    let p = bin_position(&gex_info.gex_barcodes[li], bc);
                     if p >= 0 {
                         let mut raw_count = 0 as f64;
                         if gex_info.gex_matrices[li].initialized() {
@@ -692,7 +689,7 @@ pub fn compute_bu(
                             gex_count = raw_count;
                         }
                     }
-                    if var == "gex".to_string() {
+                    if var == *"gex" {
                         row.push(format!("{}", gex_count.round()));
                     } else {
                         let mut y = var.clone();
@@ -703,11 +700,11 @@ pub fn compute_bu(
                         let suffixes = ["_min", "_max", "_μ", "_Σ", "_cell", "_%"];
                         for s in suffixes.iter() {
                             if y.ends_with(s) {
-                                y = y.rev_before(&s).to_string();
+                                y = y.rev_before(s).to_string();
                                 break;
                             }
                         }
-                        let p = bin_position(&gex_info.gex_barcodes[li], &bc);
+                        let p = bin_position(&gex_info.gex_barcodes[li], bc);
                         let mut computed = false;
                         let mut count = 0.0;
                         let l = bcl.2;
@@ -716,12 +713,11 @@ pub fn compute_bu(
                             if ctl.clono_print_opt.regex_match[li].contains_key(&y) {
                                 ux = ctl.clono_print_opt.regex_match[li][&y].clone();
                             }
-                            if ux.len() > 0 {
+                            if !ux.is_empty() {
                                 computed = true;
                                 for fid in ux.iter() {
                                     let counti = get_gex_matrix_entry(
-                                        &ctl, &gex_info, *fid, &d_all, &ind_all, li, l, p as usize,
-                                        &y,
+                                        ctl, gex_info, *fid, d_all, ind_all, li, l, p as usize, &y,
                                     );
                                     count += counti;
                                 }
@@ -729,7 +725,7 @@ pub fn compute_bu(
                                 computed = true;
                                 let fid = gex_info.feature_id[li][&y];
                                 count = get_gex_matrix_entry(
-                                    &ctl, &gex_info, fid, &d_all, &ind_all, li, l, p as usize, &y,
+                                    ctl, gex_info, fid, d_all, ind_all, li, l, p as usize, &y,
                                 );
                             }
                         }
@@ -763,19 +759,19 @@ pub fn compute_bu(
                 if m.is_some() {
                     let m = m.unwrap();
                     for p in 0..rsi.cvars[col].len() {
-                        if rsi.cvars[col][p] == "u".to_string() {
+                        if rsi.cvars[col][p] == *"u" {
                             let numi = ex.clones[bcl.2][m].umi_count;
                             cx[cp + p] = format!("{}", numi);
-                        } else if rsi.cvars[col][p] == "r".to_string() {
+                        } else if rsi.cvars[col][p] == *"r" {
                             let r = ex.clones[bcl.2][m].read_count;
                             cx[cp + p] = format!("{}", r);
-                        } else if rsi.cvars[col][p] == "nval".to_string() {
+                        } else if rsi.cvars[col][p] == *"nval" {
                             let mut n = 0;
                             if ex.clones[bcl.2][m].validated_umis.is_some() {
                                 n = ex.clones[bcl.2][m].validated_umis.as_ref().unwrap().len();
                             }
                             cx[cp + p] = format!("{}", n);
-                        } else if rsi.cvars[col][p] == "nnval".to_string() {
+                        } else if rsi.cvars[col][p] == *"nnval" {
                             let mut n = 0;
                             if ex.clones[bcl.2][m].non_validated_umis.is_some() {
                                 n = ex.clones[bcl.2][m]
@@ -785,19 +781,19 @@ pub fn compute_bu(
                                     .len();
                             }
                             cx[cp + p] = format!("{}", n);
-                        } else if rsi.cvars[col][p] == "nival".to_string() {
+                        } else if rsi.cvars[col][p] == *"nival" {
                             let mut n = 0;
                             if ex.clones[bcl.2][m].invalidated_umis.is_some() {
                                 n = ex.clones[bcl.2][m].invalidated_umis.as_ref().unwrap().len();
                             }
                             cx[cp + p] = format!("{}", n);
-                        } else if rsi.cvars[col][p] == "valumis".to_string() {
+                        } else if rsi.cvars[col][p] == *"valumis" {
                             let mut n = Vec::<String>::new();
                             if ex.clones[bcl.2][m].validated_umis.is_some() {
                                 n = ex.clones[bcl.2][m].non_validated_umis.clone().unwrap();
                             }
                             cx[cp + p] = format!("{}", n.iter().format(","));
-                        } else if rsi.cvars[col][p] == "valbcumis".to_string() {
+                        } else if rsi.cvars[col][p] == *"valbcumis" {
                             let mut n = Vec::<String>::new();
                             if ex.clones[bcl.2][m].validated_umis.is_some() {
                                 n = ex.clones[bcl.2][m].validated_umis.clone().unwrap();
@@ -810,13 +806,13 @@ pub fn compute_bu(
                                 }
                             }
                             cx[cp + p] = format!("{}", n.iter().format(","));
-                        } else if rsi.cvars[col][p] == "nvalumis".to_string() {
+                        } else if rsi.cvars[col][p] == *"nvalumis" {
                             let mut n = Vec::<String>::new();
                             if ex.clones[bcl.2][m].non_validated_umis.is_some() {
                                 n = ex.clones[bcl.2][m].non_validated_umis.clone().unwrap();
                             }
                             cx[cp + p] = format!("{}", n.iter().format(","));
-                        } else if rsi.cvars[col][p] == "nvalbcumis".to_string() {
+                        } else if rsi.cvars[col][p] == *"nvalbcumis" {
                             let mut n = Vec::<String>::new();
                             if ex.clones[bcl.2][m].non_validated_umis.is_some() {
                                 n = ex.clones[bcl.2][m].non_validated_umis.clone().unwrap();
@@ -829,13 +825,13 @@ pub fn compute_bu(
                                 }
                             }
                             cx[cp + p] = format!("{}", n.iter().format(","));
-                        } else if rsi.cvars[col][p] == "ivalumis".to_string() {
+                        } else if rsi.cvars[col][p] == *"ivalumis" {
                             let mut n = Vec::<String>::new();
                             if ex.clones[bcl.2][m].invalidated_umis.is_some() {
                                 n = ex.clones[bcl.2][m].invalidated_umis.clone().unwrap();
                             }
                             cx[cp + p] = format!("{}", n.iter().format(","));
-                        } else if rsi.cvars[col][p] == "ivalbcumis".to_string() {
+                        } else if rsi.cvars[col][p] == *"ivalbcumis" {
                             let mut n = Vec::<String>::new();
                             if ex.clones[bcl.2][m].invalidated_umis.is_some() {
                                 n = ex.clones[bcl.2][m].invalidated_umis.clone().unwrap();

--- a/enclone_print/src/print_utils5.rs
+++ b/enclone_print/src/print_utils5.rs
@@ -120,7 +120,7 @@ pub fn vars_and_shares(
                 ($u:expr, $col:expr, $var:expr, $val:expr) => {
                     if ctl.parseable_opt.pout.len() > 0
                         && (ctl.parseable_opt.pchains == "max"
-                            || $col + 1 <= ctl.parseable_opt.pchains.force_usize())
+                            || cx < ctl.parseable_opt.pchains.force_usize())
                     {
                         let varc = format!("{}{}", $var, $col + 1);
                         if pass == 2 && (pcols_sort.is_empty() || bin_member(&pcols_sort, &varc)) {
@@ -283,7 +283,7 @@ pub fn delete_weaks(
             }
         }
     }
-    vquals.sort();
+    vquals.sort_unstable();
     let mut j = 0;
     while j < vquals.len() {
         let mut k = j + 1;
@@ -369,7 +369,7 @@ pub fn build_diff_row(
         let mut row = row1.clone();
         for col in 0..cols {
             for m in 0..rsi.cvars[col].len() {
-                if rsi.cvars[col][m] == "amino".to_string() {
+                if rsi.cvars[col][m] == *"amino" {
                     let mut xdots = String::new();
                     for k in 0..show_aa[col].len() {
                         if k > 0 && field_types[col][k] != field_types[col][k - 1] {
@@ -405,9 +405,9 @@ pub fn build_diff_row(
                         unique_sort(&mut codons);
                         if codons.len() > 1 {
                             if cdr {
-                                if ctl.gen_opt.diff_style == "C1".to_string() {
+                                if ctl.gen_opt.diff_style == *"C1" {
                                     xdots.push('C');
-                                } else if ctl.gen_opt.diff_style == "C2".to_string() {
+                                } else if ctl.gen_opt.diff_style == *"C2" {
                                     xdots.push('');
                                     xdots.push('[');
                                     xdots.push('0');
@@ -433,21 +433,19 @@ pub fn build_diff_row(
                                     xdots.push('x');
                                 }
                             } else if !leader {
-                                if ctl.gen_opt.diff_style == "C1".to_string() {
+                                if ctl.gen_opt.diff_style == *"C1" {
                                     xdots.push('F');
-                                } else if ctl.gen_opt.diff_style == "C2".to_string() {
+                                } else if ctl.gen_opt.diff_style == *"C2" {
                                     xdots.push('▮');
                                 } else {
                                     xdots.push('x');
                                 }
+                            } else if ctl.gen_opt.diff_style == *"C1" {
+                                xdots.push('L');
+                            } else if ctl.gen_opt.diff_style == *"C2" {
+                                xdots.push('▮');
                             } else {
-                                if ctl.gen_opt.diff_style == "C1".to_string() {
-                                    xdots.push('L');
-                                } else if ctl.gen_opt.diff_style == "C2".to_string() {
-                                    xdots.push('▮');
-                                } else {
-                                    xdots.push('x');
-                                }
+                                xdots.push('x');
                             }
                         } else {
                             xdots.push('.');
@@ -497,7 +495,7 @@ pub fn insert_consensus_row(
         let classes = aa_classes();
         for col in 0..rsi.mat.len() {
             for m in 0..rsi.cvars[col].len() {
-                if rsi.cvars[col][m] == "amino".to_string() {
+                if rsi.cvars[col][m] == *"amino" {
                     let mut xdots = String::new();
                     for k in 0..show_aa[col].len() {
                         if k > 0 && field_types[col][k] != field_types[col][k - 1] {
@@ -521,17 +519,17 @@ pub fn insert_consensus_row(
                             }
                         }
                         if codons.solo() && gap {
-                            xdots += &"g";
+                            xdots += "g";
                         } else if codons.solo() {
                             let codon = &codons[0];
-                            let aa = codon_to_aa(&codon);
+                            let aa = codon_to_aa(codon);
                             let mut log = Vec::<u8>::new();
-                            emit_codon_color_escape(&codon, &mut log);
+                            emit_codon_color_escape(codon, &mut log);
                             log.push(aa);
                             emit_end_escape(&mut log);
-                            xdots += &strme(&log);
+                            xdots += strme(&log);
                         } else if gap {
-                            xdots += &"X";
+                            xdots += "X";
                         } else {
                             let mut aas = Vec::<u8>::new();
                             for x in codons.iter() {
@@ -541,7 +539,7 @@ pub fn insert_consensus_row(
                             if aas.solo() {
                                 xdots.push(aas[0] as char);
                             } else if style == "x" {
-                                xdots += &"X";
+                                xdots += "X";
                             } else {
                                 for m in classes.iter() {
                                     if meet_size(&aas, &m.1) == aas.len() {

--- a/enclone_print/src/print_utils5.rs
+++ b/enclone_print/src/print_utils5.rs
@@ -1,17 +1,17 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use crate::print_utils1::*;
-use amino::*;
-use ansi_escape::*;
-use enclone_core::defs::*;
-use enclone_core::print_tools::*;
-use enclone_proto::types::*;
-use itertools::*;
+use crate::print_utils1::aa_classes;
+use amino::codon_to_aa;
+use ansi_escape::emit_end_escape;
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype};
+use enclone_core::print_tools::emit_codon_color_escape;
+use enclone_proto::types::DonorReferenceItem;
+use itertools::Itertools;
 use std::cmp::max;
 use std::collections::HashMap;
-use string_utils::*;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use string_utils::{strme, TextUtils};
+use vdj_ann::refx::RefData;
+use vector_utils::{bin_member, meet_size, unique_sort, VecUtils};
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_print/src/proc_cvar1.rs
+++ b/enclone_print/src/proc_cvar1.rs
@@ -2,20 +2,20 @@
 
 // This file contains the single function proc_cvar.
 
-use crate::print_utils1::*;
-use amino::*;
-use bio_edit::alignment::pairwise::*;
+use crate::print_utils1::{cdr3_aa_con, color_codon};
+use amino::{aa_seq, codon_to_aa};
+use bio_edit::alignment::pairwise::Aligner;
 use bio_edit::alignment::AlignmentOperation::*;
-use enclone_core::align_to_vdj_ref::*;
-use enclone_core::defs::*;
-use enclone_core::opt_d::*;
-use enclone_proto::types::*;
-use itertools::*;
-use stats_utils::*;
+use enclone_core::align_to_vdj_ref::{align_to_vdj_ref, cigar};
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype};
+use enclone_core::opt_d::opt_d;
+use enclone_proto::types::DonorReferenceItem;
+use itertools::Itertools;
+use stats_utils::percent_ratio;
 use std::collections::HashMap;
-use string_utils::*;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use string_utils::{stringme, strme, TextUtils};
+use vdj_ann::refx::RefData;
+use vector_utils::{bin_member, next_diff, sort_sync2};
 
 pub fn proc_cvar1(
     var: &String,

--- a/enclone_print/src/proc_cvar1.rs
+++ b/enclone_print/src/proc_cvar1.rs
@@ -61,7 +61,7 @@ pub fn proc_cvar1(
             if pass == 2
                 && ((ctl.parseable_opt.pout.len() > 0
                     && (ctl.parseable_opt.pchains == "max"
-                        || $col + 1 <= ctl.parseable_opt.pchains.force_usize()))
+                        || col < ctl.parseable_opt.pchains.force_usize()))
                     || extra_args.len() > 0)
             {
                 let mut v = $var.clone();
@@ -148,7 +148,7 @@ pub fn proc_cvar1(
             } else {
                 let x = &peer_groups[rsi.vids[col]];
                 let last = k == show_aa[col].len() - 1;
-                let log = color_codon(&ctl, &seq_amino, &x, p, &mut last_color, last);
+                let log = color_codon(ctl, seq_amino, x, p, &mut last_color, last);
                 cx[col][j] += strme(&log);
             }
         }
@@ -163,14 +163,14 @@ pub fn proc_cvar1(
         let td = &ex.share[mid];
         let tig = &td.seq;
         let ops = align_to_vdj_ref(
-            &tig,
+            tig,
             &vref,
             &dref,
             &d2ref,
             &jref,
             "", // drefname
             ex.share[mid].left,
-            &ctl,
+            ctl,
         )
         .0;
         let c = cigar(&ops, 0, tig.len(), tig.len());
@@ -222,7 +222,7 @@ pub fn proc_cvar1(
 
             // Align the V..J sequence on the contig to the reference concatenation.
 
-            let al = aligner.semiglobal(&tig, &concat);
+            let al = aligner.semiglobal(tig, &concat);
             let mut m = 0;
             let mut pos = al.xstart;
             let mut rpos = (al.ystart as isize) - (vref.len() as isize);
@@ -282,13 +282,13 @@ pub fn proc_cvar1(
         }
         sort_sync2(&mut counts, &mut ds);
         let mut comp = 0;
-        if counts.len() > 0 {
+        if !counts.is_empty() {
             comp = counts[0];
         }
         if *var == "comp".to_string() {
             cvar_stats1![j, var, format!("{}", comp)];
         } else {
-            cvar_stats1![j, var, format!("{}", edit)];
+            cvar_stats1![j, var, edit];
         }
     } else if *var == "d1_name"
         || *var == "d2_name"
@@ -303,19 +303,9 @@ pub fn proc_cvar1(
         }
         let mut scores = Vec::<f64>::new();
         let mut ds = Vec::<Vec<usize>>::new();
-        opt_d(
-            &ex,
-            col,
-            u,
-            &rsi,
-            &refdata,
-            &dref,
-            &mut scores,
-            &mut ds,
-            &ctl,
-        );
+        opt_d(ex, col, u, rsi, refdata, dref, &mut scores, &mut ds, ctl);
         let mut opt = Vec::new();
-        if ds.len() > 0 {
+        if !ds.is_empty() {
             opt = ds[0].clone();
         }
         let mut opt2 = Vec::new();
@@ -350,7 +340,7 @@ pub fn proc_cvar1(
             cvar_stats1![j, var, opt2_name];
         } else if *var == "d#" {
             let mut score = 0.0;
-            if scores.len() > 0 {
+            if !scores.is_empty() {
                 score = scores[0];
             }
             cvar_stats1![j, var, format!("{:.1}", score)];
@@ -377,11 +367,9 @@ pub fn proc_cvar1(
         if var.ends_with("_ext") {
             left = var.between("aa_", "_").force_i64() * 3;
             right = var.after("aa_").between("_", "_").force_i64() * 3;
-        } else if var.ends_with("_north") {
-            if ex.share[mid].left {
-                left = 3 * 3;
-                right = 3 * 3;
-            }
+        } else if var.ends_with("_north") && ex.share[mid].left {
+            left = 3 * 3;
+            right = 3 * 3;
         }
         let x = &ex.share[mid];
         let mut y = "unknown".to_string();
@@ -597,9 +585,9 @@ pub fn proc_cvar1(
     } else if *var == "cdr3_aa_conx".to_string() || *var == "cdr3_aa_conp".to_string() {
         let c;
         if *var == "cdr3_aa_conx" {
-            c = cdr3_aa_con("x", col, &exacts, &exact_clonotypes, &rsi);
+            c = cdr3_aa_con("x", col, exacts, exact_clonotypes, rsi);
         } else {
-            c = cdr3_aa_con("p", col, &exacts, &exact_clonotypes, &rsi);
+            c = cdr3_aa_con("p", col, exacts, exact_clonotypes, rsi);
         }
         cvar_stats1![j, var, c];
     } else if *var == "fwr1_dna" || *var == "fwr1_aa" || *var == "fwr1_len" {
@@ -786,7 +774,7 @@ pub fn proc_cvar1(
         let dna = &x.seq_del_amino[start..stop];
         let y;
         if *var == "fwr4_dna".to_string() {
-            y = stringme(&dna);
+            y = stringme(dna);
         } else if *var == "fwr4_aa".to_string() {
             y = stringme(&aa_seq(&dna.to_vec(), 0));
         } else {

--- a/enclone_print/src/proc_cvar2.rs
+++ b/enclone_print/src/proc_cvar2.rs
@@ -54,7 +54,7 @@ pub fn proc_cvar2(
             if pass == 2
                 && ((ctl.parseable_opt.pout.len() > 0
                     && (ctl.parseable_opt.pchains == "max"
-                        || $col + 1 <= ctl.parseable_opt.pchains.force_usize()))
+                        || col < ctl.parseable_opt.pchains.force_usize()))
                     || extra_args.len() > 0)
             {
                 let mut v = $var.clone();
@@ -126,15 +126,15 @@ pub fn proc_cvar2(
     if var == "nval" {
         cvar_stats1![j, *var, "".to_string()];
         if pass == 2
-            && ((ctl.parseable_opt.pout.len() > 0
+            && ((!ctl.parseable_opt.pout.is_empty()
                 && (ctl.parseable_opt.pchains == "max"
-                    || col + 1 <= ctl.parseable_opt.pchains.force_usize()))
-                || extra_args.len() > 0)
+                    || col < ctl.parseable_opt.pchains.force_usize()))
+                || !extra_args.is_empty())
         {
             let varc = format!("{}{}", var, col + 1);
             if pcols_sort.is_empty()
-                || bin_member(&pcols_sort, &varc)
-                || bin_member(&extra_args, &varc)
+                || bin_member(pcols_sort, &varc)
+                || bin_member(extra_args, &varc)
             {
                 let mut vals = String::new();
                 let mut valsx = Vec::<String>::new();
@@ -149,22 +149,22 @@ pub fn proc_cvar2(
                     vals += &format!("{}", n);
                     valsx.push(format!("{}", n));
                 }
-                out_data[u].insert(varc.clone(), format!("{}", vals));
+                out_data[u].insert(varc.clone(), vals.to_string());
                 stats.push((varc, valsx));
             }
         }
     } else if var == "nnval" {
         cvar_stats1![j, *var, "".to_string()];
         if pass == 2
-            && ((ctl.parseable_opt.pout.len() > 0
+            && ((!ctl.parseable_opt.pout.is_empty()
                 && (ctl.parseable_opt.pchains == "max"
-                    || col + 1 <= ctl.parseable_opt.pchains.force_usize()))
-                || extra_args.len() > 0)
+                    || col < ctl.parseable_opt.pchains.force_usize()))
+                || !extra_args.is_empty())
         {
             let varc = format!("{}{}", var, col + 1);
             if pcols_sort.is_empty()
-                || bin_member(&pcols_sort, &varc)
-                || bin_member(&extra_args, &varc)
+                || bin_member(pcols_sort, &varc)
+                || bin_member(extra_args, &varc)
             {
                 let mut nvals = String::new();
                 let mut nvalsx = Vec::<String>::new();
@@ -179,22 +179,22 @@ pub fn proc_cvar2(
                     nvals += &format!("{}", n);
                     nvalsx.push(format!("{}", n));
                 }
-                out_data[u].insert(varc.clone(), format!("{}", nvals));
+                out_data[u].insert(varc.clone(), nvals.to_string());
                 stats.push((varc, nvalsx));
             }
         }
     } else if var == "nival" {
         cvar_stats1![j, *var, "".to_string()];
         if pass == 2
-            && ((ctl.parseable_opt.pout.len() > 0
+            && ((!ctl.parseable_opt.pout.is_empty()
                 && (ctl.parseable_opt.pchains == "max"
-                    || col + 1 <= ctl.parseable_opt.pchains.force_usize()))
-                || extra_args.len() > 0)
+                    || col < ctl.parseable_opt.pchains.force_usize()))
+                || !extra_args.is_empty())
         {
             let varc = format!("{}{}", var, col + 1);
             if pcols_sort.is_empty()
-                || bin_member(&pcols_sort, &varc)
-                || bin_member(&extra_args, &varc)
+                || bin_member(pcols_sort, &varc)
+                || bin_member(extra_args, &varc)
             {
                 let mut nvals = String::new();
                 let mut nvalsx = Vec::<String>::new();
@@ -209,22 +209,22 @@ pub fn proc_cvar2(
                     nvals += &format!("{}", n);
                     nvalsx.push(format!("{}", n));
                 }
-                out_data[u].insert(varc.clone(), format!("{}", nvals));
+                out_data[u].insert(varc.clone(), nvals.to_string());
                 stats.push((varc, nvalsx));
             }
         }
     } else if var == "valumis" {
         cvar_stats1![j, *var, "".to_string()];
         if pass == 2
-            && ((ctl.parseable_opt.pout.len() > 0
+            && ((!ctl.parseable_opt.pout.is_empty()
                 && (ctl.parseable_opt.pchains == "max"
-                    || col + 1 <= ctl.parseable_opt.pchains.force_usize()))
-                || extra_args.len() > 0)
+                    || col < ctl.parseable_opt.pchains.force_usize()))
+                || !extra_args.is_empty())
         {
             let varc = format!("{}{}", var, col + 1);
             if pcols_sort.is_empty()
-                || bin_member(&pcols_sort, &varc)
-                || bin_member(&extra_args, &varc)
+                || bin_member(pcols_sort, &varc)
+                || bin_member(extra_args, &varc)
             {
                 let mut vals = String::new();
                 for k in 0..ex.ncells() {
@@ -243,23 +243,23 @@ pub fn proc_cvar2(
                                 .format(",")
                         );
                     }
-                    vals += &format!("{}", n);
+                    vals += &n.to_string();
                 }
-                out_data[u].insert(varc, format!("{}", vals));
+                out_data[u].insert(varc, vals.to_string());
             }
         }
     } else if var == "valbcumis" {
         cvar_stats1![j, *var, "".to_string()];
         if pass == 2
-            && ((ctl.parseable_opt.pout.len() > 0
+            && ((!ctl.parseable_opt.pout.is_empty()
                 && (ctl.parseable_opt.pchains == "max"
-                    || col + 1 <= ctl.parseable_opt.pchains.force_usize()))
-                || extra_args.len() > 0)
+                    || col < ctl.parseable_opt.pchains.force_usize()))
+                || !extra_args.is_empty())
         {
             let varc = format!("{}{}", var, col + 1);
             if pcols_sort.is_empty()
-                || bin_member(&pcols_sort, &varc)
-                || bin_member(&extra_args, &varc)
+                || bin_member(pcols_sort, &varc)
+                || bin_member(extra_args, &varc)
             {
                 let mut vals = String::new();
                 for k in 0..ex.ncells() {
@@ -275,23 +275,23 @@ pub fn proc_cvar2(
                         }
                         n = format!("{}", bc_umis.iter().format(","));
                     }
-                    vals += &format!("{}", n);
+                    vals += &n.to_string();
                 }
-                out_data[u].insert(varc, format!("{}", vals));
+                out_data[u].insert(varc, vals.to_string());
             }
         }
     } else if var == "nvalumis" {
         cvar_stats1![j, *var, "".to_string()];
         if pass == 2
-            && ((ctl.parseable_opt.pout.len() > 0
+            && ((!ctl.parseable_opt.pout.is_empty()
                 && (ctl.parseable_opt.pchains == "max"
-                    || col + 1 <= ctl.parseable_opt.pchains.force_usize()))
-                || extra_args.len() > 0)
+                    || col < ctl.parseable_opt.pchains.force_usize()))
+                || !extra_args.is_empty())
         {
             let varc = format!("{}{}", var, col + 1);
             if pcols_sort.is_empty()
-                || bin_member(&pcols_sort, &varc)
-                || bin_member(&extra_args, &varc)
+                || bin_member(pcols_sort, &varc)
+                || bin_member(extra_args, &varc)
             {
                 let mut nvals = String::new();
                 for k in 0..ex.ncells() {
@@ -310,23 +310,23 @@ pub fn proc_cvar2(
                                 .format(",")
                         );
                     }
-                    nvals += &format!("{}", n);
+                    nvals += &n.to_string();
                 }
-                out_data[u].insert(varc, format!("{}", nvals));
+                out_data[u].insert(varc, nvals.to_string());
             }
         }
     } else if var == "nvalbcumis" {
         cvar_stats1![j, *var, "".to_string()];
         if pass == 2
-            && ((ctl.parseable_opt.pout.len() > 0
+            && ((!ctl.parseable_opt.pout.is_empty()
                 && (ctl.parseable_opt.pchains == "max"
-                    || col + 1 <= ctl.parseable_opt.pchains.force_usize()))
-                || extra_args.len() > 0)
+                    || col < ctl.parseable_opt.pchains.force_usize()))
+                || !extra_args.is_empty())
         {
             let varc = format!("{}{}", var, col + 1);
             if pcols_sort.is_empty()
-                || bin_member(&pcols_sort, &varc)
-                || bin_member(&extra_args, &varc)
+                || bin_member(pcols_sort, &varc)
+                || bin_member(extra_args, &varc)
             {
                 let mut vals = String::new();
                 for k in 0..ex.ncells() {
@@ -342,23 +342,23 @@ pub fn proc_cvar2(
                         }
                         n = format!("{}", bc_umis.iter().format(","));
                     }
-                    vals += &format!("{}", n);
+                    vals += &n.to_string();
                 }
-                out_data[u].insert(varc, format!("{}", vals));
+                out_data[u].insert(varc, vals.to_string());
             }
         }
     } else if var == "ivalumis" {
         cvar_stats1![j, *var, "".to_string()];
         if pass == 2
-            && ((ctl.parseable_opt.pout.len() > 0
+            && ((!ctl.parseable_opt.pout.is_empty()
                 && (ctl.parseable_opt.pchains == "max"
-                    || col + 1 <= ctl.parseable_opt.pchains.force_usize()))
-                || extra_args.len() > 0)
+                    || col < ctl.parseable_opt.pchains.force_usize()))
+                || !extra_args.is_empty())
         {
             let varc = format!("{}{}", var, col + 1);
             if pcols_sort.is_empty()
-                || bin_member(&pcols_sort, &varc)
-                || bin_member(&extra_args, &varc)
+                || bin_member(pcols_sort, &varc)
+                || bin_member(extra_args, &varc)
             {
                 let mut nvals = String::new();
                 for k in 0..ex.ncells() {
@@ -377,23 +377,23 @@ pub fn proc_cvar2(
                                 .format(",")
                         );
                     }
-                    nvals += &format!("{}", n);
+                    nvals += &n.to_string();
                 }
-                out_data[u].insert(varc, format!("{}", nvals));
+                out_data[u].insert(varc, nvals.to_string());
             }
         }
     } else if var == "ivalbcumis" {
         cvar_stats1![j, *var, "".to_string()];
         if pass == 2
-            && ((ctl.parseable_opt.pout.len() > 0
+            && ((!ctl.parseable_opt.pout.is_empty()
                 && (ctl.parseable_opt.pchains == "max"
-                    || col + 1 <= ctl.parseable_opt.pchains.force_usize()))
-                || extra_args.len() > 0)
+                    || col < ctl.parseable_opt.pchains.force_usize()))
+                || !extra_args.is_empty())
         {
             let varc = format!("{}{}", var, col + 1);
             if pcols_sort.is_empty()
-                || bin_member(&pcols_sort, &varc)
-                || bin_member(&extra_args, &varc)
+                || bin_member(pcols_sort, &varc)
+                || bin_member(extra_args, &varc)
             {
                 let mut vals = String::new();
                 for k in 0..ex.ncells() {
@@ -409,9 +409,9 @@ pub fn proc_cvar2(
                         }
                         n = format!("{}", bc_umis.iter().format(","));
                     }
-                    vals += &format!("{}", n);
+                    vals += &n.to_string();
                 }
-                out_data[u].insert(varc, format!("{}", vals));
+                out_data[u].insert(varc, vals.to_string());
             }
         }
     } else if *var == "cdiff" {
@@ -565,11 +565,11 @@ pub fn proc_cvar2(
         let var = var.clone();
         if pass == 2
             && ((ctl.parseable_opt.pchains == "max"
-                || col + 1 <= ctl.parseable_opt.pchains.force_usize())
-                || extra_args.len() > 0)
+                || col < ctl.parseable_opt.pchains.force_usize())
+                || !extra_args.is_empty())
         {
             let varc = format!("{}{}", var, col + 1);
-            if pcols_sort.is_empty() || bin_member(&pcols_sort, &varc) {
+            if pcols_sort.is_empty() || bin_member(pcols_sort, &varc) {
                 let mut vals = String::new();
                 for k in 0..ex.ncells() {
                     if k > 0 {
@@ -577,7 +577,7 @@ pub fn proc_cvar2(
                     }
                     vals += &format!("{}", ex.clones[k][mid].umi_count);
                 }
-                out_data[u].insert(varc, format!("{}", vals));
+                out_data[u].insert(varc, vals.to_string());
             }
         }
     } else if *var == "u_min" {
@@ -606,13 +606,13 @@ pub fn proc_cvar2(
         let var = var.clone();
         if pass == 2
             && ((ctl.parseable_opt.pchains == "max"
-                || col + 1 <= ctl.parseable_opt.pchains.force_usize())
-                || extra_args.len() > 0)
+                || col < ctl.parseable_opt.pchains.force_usize())
+                || !extra_args.is_empty())
         {
             let varc = format!("{}{}", var, col + 1);
             if pcols_sort.is_empty()
-                || bin_member(&pcols_sort, &varc)
-                || bin_member(&extra_args, &varc)
+                || bin_member(pcols_sort, &varc)
+                || bin_member(extra_args, &varc)
             {
                 let mut vals = String::new();
                 for k in 0..ex.ncells() {
@@ -621,7 +621,7 @@ pub fn proc_cvar2(
                     }
                     vals += &format!("{}", ex.clones[k][mid].read_count);
                 }
-                out_data[u].insert(varc, format!("{}", vals));
+                out_data[u].insert(varc, vals.to_string());
             }
         }
     } else if *var == "d_frame" {
@@ -714,5 +714,5 @@ pub fn proc_cvar2(
     } else {
         return false;
     }
-    return true;
+    true
 }

--- a/enclone_print/src/proc_cvar2.rs
+++ b/enclone_print/src/proc_cvar2.rs
@@ -2,15 +2,15 @@
 
 // This file contains the single function proc_cvar.
 
-use enclone_core::defs::*;
-use enclone_proto::types::*;
-use itertools::*;
-use stats_utils::*;
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype, POUT_SEP};
+use enclone_proto::types::DonorReferenceItem;
+use itertools::Itertools;
+use stats_utils::percent_ratio;
 use std::cmp::min;
 use std::collections::HashMap;
-use string_utils::*;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use string_utils::{stringme, TextUtils};
+use vdj_ann::refx::RefData;
+use vector_utils::{bin_member, next_diff12_4, unique_sort};
 
 pub fn proc_cvar2(
     var: &String,

--- a/enclone_print/src/proc_lvar1.rs
+++ b/enclone_print/src/proc_lvar1.rs
@@ -3,14 +3,14 @@
 // This file contains the single function proc_lvar,
 // plus a small helper function get_gex_matrix_entry.
 
-use enclone_core::defs::*;
-use enclone_core::median::*;
-use enclone_proto::types::*;
-use itertools::*;
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype, GexInfo, POUT_SEP};
+use enclone_core::median::median_f64;
+use enclone_proto::types::DonorReferenceItem;
+use itertools::Itertools;
 use std::collections::HashMap;
-use string_utils::*;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use string_utils::{abbrev_list, strme, TextUtils};
+use vdj_ann::refx::RefData;
+use vector_utils::{bin_member, unique_sort};
 
 pub fn get_gex_matrix_entry(
     ctl: &EncloneControl,

--- a/enclone_print/src/proc_lvar1.rs
+++ b/enclone_print/src/proc_lvar1.rs
@@ -168,13 +168,13 @@ pub fn proc_lvar1(
                     let mut tag = String::new();
                     for j in 0..ex.share.len() {
                         if ex.share[j].left {
-                            tag += &strme(&ex.share[j].seq);
+                            tag += strme(&ex.share[j].seq);
                         }
                     }
                     tag += "_";
                     for j in 0..ex.share.len() {
                         if !ex.share[j].left {
-                            tag += &strme(&ex.share[j].seq);
+                            tag += strme(&ex.share[j].seq);
                         }
                     }
                     if ctl.gen_opt.info_data.contains_key(&tag) {
@@ -308,8 +308,8 @@ pub fn proc_lvar1(
         for x in clust.iter() {
             clustf.push(format!("{}", x));
         }
-        clust.sort();
-        lvar_stats![i, x, format!("{}", abbrev_list(&clust)), clustf];
+        clust.sort_unstable();
+        lvar_stats![i, x, abbrev_list(&clust), clustf];
     } else if x == "n_other" {
         let mut n = 0;
         let mut ns = Vec::<String>::new();
@@ -360,7 +360,7 @@ pub fn proc_lvar1(
         }
         */
         cell_types.sort();
-        lvar![i, x, format!("{}", abbrev_list(&cell_types))];
+        lvar![i, x, abbrev_list(&cell_types)];
     } else if x == "filter" {
         let mut fates = Vec::<String>::new();
         for j in 0..ex.clones.len() {
@@ -492,7 +492,7 @@ pub fn proc_lvar1(
                 speak!(u, x, format!("{}", r.iter().format(POUT_SEP)));
             }
         }
-    } else if bin_member(&alt_bcs, x) {
+    } else if bin_member(alt_bcs, x) {
         let mut r = Vec::<String>::new();
         for l in 0..ex.clones.len() {
             let li = ex.clones[l][0].dataset_index;
@@ -500,10 +500,8 @@ pub fn proc_lvar1(
             let mut val = String::new();
             let alt = &ctl.origin_info.alt_bc_fields[li];
             for j in 0..alt.len() {
-                if alt[j].0 == *x {
-                    if alt[j].1.contains_key(&bc.clone()) {
-                        val = alt[j].1[&bc.clone()].clone();
-                    }
+                if alt[j].0 == *x && alt[j].1.contains_key(&bc.clone()) {
+                    val = alt[j].1[&bc.clone()].clone();
                 }
             }
             r.push(val);
@@ -542,5 +540,5 @@ pub fn proc_lvar1(
     } else {
         return false;
     }
-    return true;
+    true
 }

--- a/enclone_print/src/proc_lvar2.rs
+++ b/enclone_print/src/proc_lvar2.rs
@@ -509,11 +509,12 @@ pub fn proc_lvar2(
         let ncols = gex_info.fb_top_matrices[0].ncols();
         if !x.ends_with("_n") {
             let n = x.after("fb").force_usize() - 1;
-            let mut fb = String::new();
-            if n < ncols {
-                fb = gex_info.fb_top_matrices[0].col_label(n).clone();
-            }
-            lvar![i, x, fb.clone()];
+            let fb = if n < ncols {
+                gex_info.fb_top_matrices[0].col_label(n)
+            } else {
+                String::new()
+            };
+            lvar![i, x, (*fb).to_string()];
         } else {
             let n = x.after("fb").rev_before("_n").force_usize() - 1;
             if n >= ncols {

--- a/enclone_print/src/proc_lvar2.rs
+++ b/enclone_print/src/proc_lvar2.rs
@@ -274,12 +274,12 @@ pub fn proc_lvar2(
             lvar_stats1![i, x, format!("{}", dist)];
         }
     } else if x == "far" {
-        let mut dist = -1 as isize;
+        let mut dist = -1_isize;
         for i2 in 0..varmat.len() {
             if i2 == u || fp[i2] != fp[u] {
                 continue;
             }
-            let mut d = 0 as isize;
+            let mut d = 0_isize;
             for c in fp[u].iter() {
                 for j in 0..varmat[u][*c].len() {
                     if varmat[u][*c][j] != varmat[i2][*c][j] {
@@ -289,7 +289,7 @@ pub fn proc_lvar2(
             }
             dist = max(dist, d);
         }
-        if dist == -1 as isize {
+        if dist == -1_isize {
             lvar_stats1![i, x, "".to_string()];
         } else {
             lvar_stats1![i, x, format!("{}", dist)];
@@ -308,7 +308,7 @@ pub fn proc_lvar2(
                 let fwr2 = ex.share[j].fr2_start.unwrap();
                 if cdr1 < fwr2 {
                     let aa = aa_seq(&ex.share[j].seq[cdr1..fwr2], 0);
-                    n += reg.find_iter(&strme(&aa)).count();
+                    n += reg.find_iter(strme(&aa)).count();
                 }
             }
         }
@@ -327,7 +327,7 @@ pub fn proc_lvar2(
                 let fwr3 = ex.share[j].fr3_start.unwrap();
                 if cdr2 < fwr3 {
                     let aa = aa_seq(&ex.share[j].seq[cdr2..fwr3], 0);
-                    n += reg.find_iter(&strme(&aa)).count();
+                    n += reg.find_iter(strme(&aa)).count();
                 }
             }
         }
@@ -344,7 +344,7 @@ pub fn proc_lvar2(
             let cdr3 = ex.share[j].cdr3_start;
             let fwr4 = cdr3 + 3 * ex.share[j].cdr3_aa.len();
             let aa = aa_seq(&ex.share[j].seq[cdr3..fwr4], 0);
-            n += reg.find_iter(&strme(&aa)).count();
+            n += reg.find_iter(strme(&aa)).count();
         }
         lvar_stats![i, x, format!("{}", n), vec![format!("{}", n); ex.ncells()]];
     } else if x.starts_with("count_fwr1_") || x.contains(":count_fwr1_") {
@@ -361,7 +361,7 @@ pub fn proc_lvar2(
                 let cdr1 = ex.share[j].cdr1_start.unwrap();
                 if fwr1 < cdr1 {
                     let aa = aa_seq(&ex.share[j].seq[fwr1..cdr1], 0);
-                    n += reg.find_iter(&strme(&aa)).count();
+                    n += reg.find_iter(strme(&aa)).count();
                 }
             }
         }
@@ -380,7 +380,7 @@ pub fn proc_lvar2(
                 let cdr2 = ex.share[j].cdr2_start.unwrap();
                 if fwr2 < cdr2 {
                     let aa = aa_seq(&ex.share[j].seq[fwr2..cdr2], 0);
-                    n += reg.find_iter(&strme(&aa)).count();
+                    n += reg.find_iter(strme(&aa)).count();
                 }
             }
         }
@@ -399,7 +399,7 @@ pub fn proc_lvar2(
                 let cdr3 = ex.share[j].cdr3_start;
                 if fwr3 < cdr3 {
                     let aa = aa_seq(&ex.share[j].seq[fwr3..cdr3], 0);
-                    n += reg.find_iter(&strme(&aa)).count();
+                    n += reg.find_iter(strme(&aa)).count();
                 }
             }
         }
@@ -415,7 +415,7 @@ pub fn proc_lvar2(
         for j in 0..ex.share.len() {
             let fwr4 = ex.share[j].cdr3_start + 3 * ex.share[j].cdr3_aa.len();
             let aa = aa_seq(&ex.share[j].seq[fwr4..], 0);
-            n += reg.find_iter(&strme(&aa)).count();
+            n += reg.find_iter(strme(&aa)).count();
         }
         lvar_stats![i, x, format!("{}", n), vec![format!("{}", n); ex.ncells()]];
     } else if x.starts_with("count_cdr_") || x.contains(":count_cdr_") {
@@ -432,7 +432,7 @@ pub fn proc_lvar2(
                 let fwr2 = ex.share[j].fr2_start.unwrap();
                 if cdr1 < fwr2 {
                     let aa = aa_seq(&ex.share[j].seq[cdr1..fwr2], 0);
-                    n += reg.find_iter(&strme(&aa)).count();
+                    n += reg.find_iter(strme(&aa)).count();
                 }
             }
             if ex.share[j].cdr2_start.is_some() && ex.share[j].fr3_start.is_some() {
@@ -440,13 +440,13 @@ pub fn proc_lvar2(
                 let fwr3 = ex.share[j].fr3_start.unwrap();
                 if cdr2 < fwr3 {
                     let aa = aa_seq(&ex.share[j].seq[cdr2..fwr3], 0);
-                    n += reg.find_iter(&strme(&aa)).count();
+                    n += reg.find_iter(strme(&aa)).count();
                 }
             }
             let cdr3 = ex.share[j].cdr3_start;
             let fwr4 = cdr3 + 3 * ex.share[j].cdr3_aa.len();
             let aa = aa_seq(&ex.share[j].seq[cdr3..fwr4], 0);
-            n += reg.find_iter(&strme(&aa)).count();
+            n += reg.find_iter(strme(&aa)).count();
         }
         lvar_stats![i, x, format!("{}", n), vec![format!("{}", n); ex.ncells()]];
     } else if x.starts_with("count_fwr_") || x.contains(":count_fwr_") {
@@ -463,7 +463,7 @@ pub fn proc_lvar2(
                 let cdr1 = ex.share[j].cdr1_start.unwrap();
                 if fwr1 < cdr1 {
                     let aa = aa_seq(&ex.share[j].seq[fwr1..cdr1], 0);
-                    n += reg.find_iter(&strme(&aa)).count();
+                    n += reg.find_iter(strme(&aa)).count();
                 }
             }
             if ex.share[j].fr2_start.is_some() && ex.share[j].cdr2_start.is_some() {
@@ -471,7 +471,7 @@ pub fn proc_lvar2(
                 let cdr2 = ex.share[j].cdr2_start.unwrap();
                 if fwr2 < cdr2 {
                     let aa = aa_seq(&ex.share[j].seq[fwr2..cdr2], 0);
-                    n += reg.find_iter(&strme(&aa)).count();
+                    n += reg.find_iter(strme(&aa)).count();
                 }
             }
             if ex.share[j].fr3_start.is_some() {
@@ -479,12 +479,12 @@ pub fn proc_lvar2(
                 let cdr3 = ex.share[j].cdr3_start;
                 if fwr3 < cdr3 {
                     let aa = aa_seq(&ex.share[j].seq[fwr3..cdr3], 0);
-                    n += reg.find_iter(&strme(&aa)).count();
+                    n += reg.find_iter(strme(&aa)).count();
                 }
             }
             let fwr4 = ex.share[j].cdr3_start + 3 * ex.share[j].cdr3_aa.len();
             let aa = aa_seq(&ex.share[j].seq[fwr4..], 0);
-            n += reg.find_iter(&strme(&aa)).count();
+            n += reg.find_iter(strme(&aa)).count();
         }
         lvar_stats![i, x, format!("{}", n), vec![format!("{}", n); ex.ncells()]];
     } else if x.starts_with("count_") || x.contains(":count_") {
@@ -497,7 +497,7 @@ pub fn proc_lvar2(
         let mut n = 0;
         for j in 0..ex.share.len() {
             let aa = aa_seq(&ex.share[j].seq, 0); // seems inefficient
-            n += reg.find_iter(&strme(&aa)).count();
+            n += reg.find_iter(strme(&aa)).count();
         }
         lvar_stats![i, x, format!("{}", n), vec![format!("{}", n); ex.ncells()]];
     } else if x.starts_with("fb")
@@ -534,7 +534,7 @@ pub fn proc_lvar2(
                         counts_sorted.push(x);
                     }
                 }
-                counts_sorted.sort();
+                counts_sorted.sort_unstable();
                 let median = rounded_median(&counts_sorted);
                 lvar_stats![i, x, format!("{}", median), counts];
             }
@@ -653,7 +653,7 @@ pub fn proc_lvar2(
             let suffixes = ["_min", "_max", "_μ", "_Σ", "_cell", "_%"];
             for s in suffixes.iter() {
                 if y.ends_with(s) {
-                    y = y.rev_before(&s).to_string();
+                    y = y.rev_before(s).to_string();
                     break;
                 }
             }
@@ -666,32 +666,30 @@ pub fn proc_lvar2(
             if ctl.clono_print_opt.regex_match[li].contains_key(&y) {
                 ux = ctl.clono_print_opt.regex_match[li][&y].clone();
             }
-            if ux.len() > 0 {
+            if !ux.is_empty() {
                 let p = bin_position(&gex_info.gex_barcodes[li], &bc);
                 if p >= 0 {
                     computed = true;
                     let mut raw_count = 0.0;
                     for fid in ux.iter() {
                         let raw_counti = get_gex_matrix_entry(
-                            &ctl, &gex_info, *fid, &d_all, &ind_all, li, l, p as usize, &y,
+                            ctl, gex_info, *fid, d_all, ind_all, li, l, p as usize, &y,
                         );
                         raw_count += raw_counti;
                     }
                     counts_sub.push(raw_count.round() as usize);
                     fcounts_sub.push(raw_count);
                 }
-            } else {
-                if gex_info.feature_id[li].contains_key(&y) {
-                    computed = true;
-                    let p = bin_position(&gex_info.gex_barcodes[li], &bc);
-                    if p >= 0 {
-                        let fid = gex_info.feature_id[li][&y];
-                        let raw_count = get_gex_matrix_entry(
-                            &ctl, &gex_info, fid, &d_all, &ind_all, li, l, p as usize, &y,
-                        );
-                        counts_sub.push(raw_count.round() as usize);
-                        fcounts_sub.push(raw_count);
-                    }
+            } else if gex_info.feature_id[li].contains_key(&y) {
+                computed = true;
+                let p = bin_position(&gex_info.gex_barcodes[li], &bc);
+                if p >= 0 {
+                    let fid = gex_info.feature_id[li][&y];
+                    let raw_count = get_gex_matrix_entry(
+                        ctl, gex_info, fid, d_all, ind_all, li, l, p as usize, &y,
+                    );
+                    counts_sub.push(raw_count.round() as usize);
+                    fcounts_sub.push(raw_count);
                 }
             }
         }
@@ -714,7 +712,7 @@ pub fn proc_lvar2(
                 stats.push((x.clone(), f));
             }
             let mut counts_sub_sorted = counts_sub.clone();
-            counts_sub_sorted.sort();
+            counts_sub_sorted.sort_unstable();
             let sum = fcounts_sub.iter().sum::<f64>();
             let mean = sum / counts_sub.len() as f64;
 
@@ -732,28 +730,26 @@ pub fn proc_lvar2(
                     let val = format!("{}", counts_sub.iter().format(POUT_SEP));
                     speak!(u, x, val);
                 }
+            } else if y0.ends_with("_min") {
+                lvar![i, x, format!("{}", counts_sub_sorted[0])];
+            } else if y0.ends_with("_max") {
+                lvar![i, x, format!("{}", counts_sub_sorted[counts_sub.len() - 1])];
+            } else if y0.ends_with("_μ") {
+                lvar![i, x, format!("{}", mean.round())];
+            } else if y0.ends_with("_Σ") {
+                lvar![i, x, format!("{}", sum.round())];
+            } else if y0.ends_with("_%") {
+                lvar![i, x, format!("{:.2}", (100.0 * sum) / gex_sum)];
             } else {
-                if y0.ends_with("_min") {
-                    lvar![i, x, format!("{}", counts_sub_sorted[0])];
-                } else if y0.ends_with("_max") {
-                    lvar![i, x, format!("{}", counts_sub_sorted[counts_sub.len() - 1])];
-                } else if y0.ends_with("_μ") {
-                    lvar![i, x, format!("{}", mean.round())];
-                } else if y0.ends_with("_Σ") {
-                    lvar![i, x, format!("{}", sum.round())];
-                } else if y0.ends_with("_%") {
-                    lvar![i, x, format!("{:.2}", (100.0 * sum) / gex_sum)];
-                } else {
-                    let mut median = 0;
-                    if counts_sub_sorted.len() > 0 {
-                        median = rounded_median(&counts_sub_sorted);
-                    }
-                    lvar![i, x, format!("{}", median)];
+                let mut median = 0;
+                if !counts_sub_sorted.is_empty() {
+                    median = rounded_median(&counts_sub_sorted);
                 }
+                lvar![i, x, format!("{}", median)];
             }
         } else if i < lvars.len() {
             lvar_stats1![i, x, "".to_string()];
         }
     }
-    return true;
+    true
 }

--- a/enclone_print/src/proc_lvar2.rs
+++ b/enclone_print/src/proc_lvar2.rs
@@ -3,17 +3,17 @@
 // This file contains the single function proc_lvar,
 // plus a small helper function get_gex_matrix_entry.
 
-use amino::*;
-use enclone_core::defs::*;
-use enclone_core::median::*;
-use enclone_proto::types::*;
-use itertools::*;
+use amino::{aa_seq, codon_to_aa};
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype, GexInfo, POUT_SEP};
+use enclone_core::median::rounded_median;
+use enclone_proto::types::DonorReferenceItem;
+use itertools::Itertools;
 use regex::Regex;
 use std::cmp::{max, min};
 use std::collections::HashMap;
-use string_utils::*;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use string_utils::{strme, TextUtils};
+use vdj_ann::refx::RefData;
+use vector_utils::{bin_member, bin_position, next_diff};
 
 pub fn get_gex_matrix_entry(
     ctl: &EncloneControl,

--- a/enclone_tail/src/align_n.rs
+++ b/enclone_tail/src/align_n.rs
@@ -2,20 +2,20 @@
 //
 // Parallelized precompute for ALIGN<n> and JALIGN<n>.
 
-use align_tools::*;
-use amino::*;
-use ansi_escape::*;
-use enclone_core::align_to_vdj_ref::*;
-use enclone_core::defs::*;
-use enclone_core::opt_d::*;
-use enclone_proto::types::*;
-use io_utils::*;
+use align_tools::vis_align;
+use amino::codon_to_aa;
+use ansi_escape::{emit_end_escape, print_color};
+use enclone_core::align_to_vdj_ref::align_to_vdj_ref;
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype};
+use enclone_core::opt_d::{jflank, opt_d, vflank};
+use enclone_proto::types::DonorReferenceItem;
+use io_utils::fwrite;
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::io::Write;
-use string_utils::*;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use string_utils::{stringme, strme};
+use vdj_ann::refx::RefData;
+use vector_utils::unique_sort;
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_tail/src/align_n.rs
+++ b/enclone_tail/src/align_n.rs
@@ -80,7 +80,7 @@ fn print_vis_align(
         vdj = stringme(&vdj_bytes);
         for (i, line) in vis.lines().enumerate() {
             if i % 4 != 2 {
-                vis_new += line.clone();
+                vis_new += line;
                 vis_new += "\n";
             } else {
                 let mut log = Vec::<u8>::new();

--- a/enclone_tail/src/alluvial_fb.rs
+++ b/enclone_tail/src/alluvial_fb.rs
@@ -3,15 +3,15 @@
 // Make alluvial tables for feature barcode data.  We determine cellular using vdj_cells,
 // which is not the only way of doing it.
 
-use enclone_core::defs::*;
-use io_utils::*;
-use stats_utils::*;
+use enclone_core::defs::{EncloneControl, GexInfo};
+use io_utils::fwrite;
+use stats_utils::percent_ratio;
 use std::cmp::max;
 use std::collections::HashMap;
 use std::io::Write;
-use string_utils::*;
-use tables::*;
-use vector_utils::*;
+use string_utils::{parse_csv, TextUtils};
+use tables::print_tabular_vbox;
+use vector_utils::{bin_member, unique_sort};
 
 pub fn alluvial_fb(
     ctl: &EncloneControl,

--- a/enclone_tail/src/assign_cell_color.rs
+++ b/enclone_tail/src/assign_cell_color.rs
@@ -2,15 +2,15 @@
 
 // Assign the color to a cell in a honeycomb plot.
 
-use crate::*;
-use ansi_escape::*;
-use enclone_core::cell_color::*;
-use enclone_core::defs::*;
+use crate::TextUtils;
+use ansi_escape::print_color13;
+use enclone_core::cell_color::CellColor;
+use enclone_core::defs::{EncloneControl, ExactClonotype, PlotOpt, POUT_SEP};
 use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::sync::Mutex;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use vdj_ann::refx::RefData;
+use vector_utils::{bin_position, unique_sort, VecUtils};
 
 // The use of these global variables is horrible.  It already lead to one bug that was very
 // difficult to track down.

--- a/enclone_tail/src/circles_to_svg.rs
+++ b/enclone_tail/src/circles_to_svg.rs
@@ -4,7 +4,7 @@
 // circles on a canvas of fixed size.  The circles are moved and resized accordingly.
 // Also shades smoothed polygons.  Also add tooltip notes if requested.
 
-use crate::polygon::*;
+use crate::polygon::Polygon;
 use std::collections::HashMap;
 
 pub fn circles_to_svg(

--- a/enclone_tail/src/clustal.rs
+++ b/enclone_tail/src/clustal.rs
@@ -5,14 +5,14 @@
 // 2. https://www.ebi.ac.uk/seqdb/confluence/display/THD/Help+-+Clustal+Omega+FAQ
 //    at "What do the consensus symbols mean in the alignment?".
 
-use enclone_core::defs::*;
-use io_utils::*;
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype};
+use io_utils::{fwrite, fwriteln};
 use std::fs::File;
 use std::io::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
-use string_utils::*;
+use string_utils::strme;
 use tar::{Builder, Header};
-use vector_utils::*;
+use vector_utils::{unique_sort, VecUtils};
 
 pub fn print_clustal(
     i: usize,

--- a/enclone_tail/src/display_tree.rs
+++ b/enclone_tail/src/display_tree.rs
@@ -8,7 +8,7 @@
 
 use itertools::Itertools;
 use std::cmp::max;
-use vector_utils::*;
+use vector_utils::sort_sync2;
 
 // vnames: vertex names
 // directed edges: {(v, w, weight)}

--- a/enclone_tail/src/fasta.rs
+++ b/enclone_tail/src/fasta.rs
@@ -1,11 +1,11 @@
 // Copyright (c) 2021 10x Genomics, Inc. All rights reserved.
 
-use amino::*;
-use enclone_core::defs::*;
-use io_utils::*;
+use amino::aa_seq;
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype};
+use io_utils::fwriteln;
 use std::io::Write;
-use string_utils::*;
-use vdj_ann::refx::*;
+use string_utils::strme;
+use vdj_ann::refx::RefData;
 
 pub fn generate_fasta(
     i: usize,

--- a/enclone_tail/src/group.rs
+++ b/enclone_tail/src/group.rs
@@ -5,26 +5,31 @@
 //
 // To keep compilation time down, this crate should not reach into the enclone crate.
 
-use crate::align_n::*;
-use crate::clustal::*;
-use crate::fasta::*;
-use crate::phylip::*;
-use crate::plot::*;
-use crate::plot_points::*;
-use crate::print_stats::*;
-use crate::requirements::*;
-use crate::sim_mat_plot::*;
-use crate::tree::*;
-use ansi_escape::ansi_to_html::*;
-use ansi_escape::*;
-use enclone_core::combine_group_pics::*;
-use enclone_core::defs::*;
-use enclone_core::mammalian_fixed_len::*;
-use enclone_core::print_tools::*;
-use enclone_core::set_speakers::*;
-use enclone_proto::types::*;
-use io_utils::*;
-use itertools::*;
+use crate::align_n::align_n;
+use crate::clustal::print_clustal;
+use crate::fasta::generate_fasta;
+use crate::phylip::print_phylip;
+use crate::plot::plot_clonotypes;
+use crate::plot_points::plot_points;
+use crate::print_stats::print_stats;
+use crate::requirements::test_requirements;
+use crate::sim_mat_plot::sim_mat_plot;
+use crate::tree::print_tree;
+use ansi_escape::ansi_to_html::{
+    compress_ansi_escapes, convert_text_with_ansi_escapes_to_html,
+    convert_text_with_ansi_escapes_to_svg,
+};
+use ansi_escape::{emit_bold_escape, emit_eight_bit_color_escape, emit_end_escape};
+use enclone_core::combine_group_pics::combine_group_pics;
+use enclone_core::defs::{
+    justification, ColInfo, EncloneControl, ExactClonotype, GexInfo, POUT_SEP,
+};
+use enclone_core::mammalian_fixed_len::mammalian_fixed_len_peer_groups;
+use enclone_core::print_tools::font_face_in_css;
+use enclone_core::set_speakers::set_speakers;
+use enclone_proto::types::DonorReferenceItem;
+use io_utils::{fwrite, fwriteln, open_for_write_new};
+use itertools::Itertools;
 use std::cmp::max;
 use std::collections::HashMap;
 use std::env;
@@ -33,11 +38,11 @@ use std::io::stdout;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 use std::time::Instant;
-use string_utils::*;
-use tables::*;
+use string_utils::{stringme, strme, TextUtils};
+use tables::print_tabular;
 use tar::Builder;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use vdj_ann::refx::RefData;
+use vector_utils::{next_diff1_3, unique_sort};
 
 pub fn group_and_print_clonotypes(
     tall: &Instant,

--- a/enclone_tail/src/grouper.rs
+++ b/enclone_tail/src/grouper.rs
@@ -7,14 +7,14 @@
 // group object: a vector of pairs (i, msg) where i is an index into exacts and msg is a message
 //               to be printed
 
-use amino::*;
+use amino::aa_seq;
 use edit_distance::edit_distance;
-use enclone_core::defs::*;
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype};
 use equiv::EquivRel;
 use rayon::prelude::*;
-use string_utils::*;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use string_utils::{strme, TextUtils};
+use vdj_ann::refx::RefData;
+use vector_utils::{next_diff1_2, sort_sync2};
 
 pub fn grouper(
     refdata: &RefData,

--- a/enclone_tail/src/legend.rs
+++ b/enclone_tail/src/legend.rs
@@ -1,13 +1,13 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use crate::assign_cell_color::*;
-use crate::colors::*;
-use crate::string_width::*;
-use crate::ticks::*;
-use crate::*;
-use enclone_core::cell_color::*;
-use enclone_core::defs::*;
-use string_utils::*;
+use crate::assign_cell_color::{VAR_HIGH, VAR_LOW};
+use crate::colors::TURBO_SRGB_BYTES;
+use crate::string_width::arial_width;
+use crate::ticks::ticks;
+use crate::{set_svg_height, set_svg_width, BOUNDARY};
+use enclone_core::cell_color::CellColor;
+use enclone_core::defs::PlotOpt;
+use string_utils::TextUtils;
 
 pub fn add_legend_for_color_by_variable(
     plot_opt: &PlotOpt,

--- a/enclone_tail/src/lib.rs
+++ b/enclone_tail/src/lib.rs
@@ -29,7 +29,7 @@ pub mod tail;
 pub mod ticks;
 pub mod tree;
 
-use string_utils::*;
+use string_utils::TextUtils;
 
 const BOUNDARY: usize = 10;
 

--- a/enclone_tail/src/lib.rs
+++ b/enclone_tail/src/lib.rs
@@ -1,7 +1,5 @@
 // Copyright (c) 2021 10x Genomics, Inc. All rights reserved.
 
-extern crate enclone_core;
-
 pub mod align_n;
 pub mod alluvial_fb;
 pub mod assign_cell_color;

--- a/enclone_tail/src/pack_circles.rs
+++ b/enclone_tail/src/pack_circles.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use crate::polygon::*;
+use crate::polygon::{Point, Polygon};
 use rayon::prelude::*;
 
 // Pack circles of given radii, which should be in descending order.  Return centers for the

--- a/enclone_tail/src/phylip.rs
+++ b/enclone_tail/src/phylip.rs
@@ -7,12 +7,12 @@
 // code left in place in case it turns out that folding is needed.  This will involve
 // a bit more than lowering W.
 
-use enclone_core::defs::*;
-use io_utils::*;
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype};
+use io_utils::{fwrite, fwriteln};
 use std::fs::File;
 use std::io::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
-use string_utils::*;
+use string_utils::strme;
 use tar::{Builder, Header};
 
 pub fn print_phylip(

--- a/enclone_tail/src/plot.rs
+++ b/enclone_tail/src/plot.rs
@@ -5,28 +5,30 @@
 // In some cases, by eye, you can see rounder forms that could be created by relocating some of
 // the cells.
 
-use crate::assign_cell_color::*;
-use crate::circles_to_svg::*;
-use crate::colors::*;
-use crate::group_colors::*;
-use crate::legend::*;
-use crate::pack_circles::*;
-use crate::plot_utils::*;
-use crate::polygon::*;
-use crate::string_width::*;
-use crate::*;
-use ansi_escape::*;
-use enclone_core::cell_color::*;
-use enclone_core::convert_svg_to_png::*;
-use enclone_core::defs::*;
-use io_utils::*;
+use crate::assign_cell_color::{VAR_HIGH, VAR_LOW};
+use crate::circles_to_svg::circles_to_svg;
+use crate::colors::{turbo_color_names, TURBO_SRGB_BYTES};
+use crate::group_colors::make_group_colors;
+use crate::legend::add_legend_for_color_by_variable;
+use crate::pack_circles::pack_circles;
+use crate::plot_utils::build_clusters;
+use crate::polygon::{enclosing_polygon, Polygon};
+use crate::string_width::arial_width;
+use crate::{get_svg_height, set_svg_height, set_svg_width, substitute_enclone_color, BOUNDARY};
+use ansi_escape::print_color13;
+use enclone_core::cell_color::CellColor;
+use enclone_core::convert_svg_to_png::convert_svg_to_png;
+use enclone_core::defs::{EncloneControl, ExactClonotype, PlotOpt, POUT_SEP};
+use io_utils::{fwriteln, open_for_read, open_for_write_new};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::time::Instant;
-use string_utils::*;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use string_utils::TextUtils;
+use vdj_ann::refx::RefData;
+use vector_utils::{
+    bin_position, next_diff1_2, next_diff1_3, position, reverse_sort, unique_sort, VecUtils,
+};
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_tail/src/plot_points.rs
+++ b/enclone_tail/src/plot_points.rs
@@ -11,8 +11,8 @@
 //
 // If symmetric = true, produce a square plot having the same range and tic marks on both axes.
 
-use crate::string_width::*;
-use crate::ticks::*;
+use crate::string_width::arial_width;
+use crate::ticks::ticks;
 use plotters::prelude::*;
 use std::cmp::max;
 

--- a/enclone_tail/src/plot_utils.rs
+++ b/enclone_tail/src/plot_utils.rs
@@ -1,13 +1,13 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use crate::assign_cell_color::*;
-use crate::colors::*;
-use crate::hex::*;
-use crate::*;
-use enclone_core::defs::*;
+use crate::assign_cell_color::assign_cell_color;
+use crate::colors::turbo_color_names;
+use crate::hex::hex_coord;
+use crate::{substitute_enclone_color, TextUtils};
+use enclone_core::defs::{EncloneControl, ExactClonotype, PlotOpt};
 use std::collections::HashMap;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use vdj_ann::refx::RefData;
+use vector_utils::{bin_position, make_freq, sort_sync2};
 
 #[derive(Clone)]
 pub struct PlotCluster {

--- a/enclone_tail/src/polygon.rs
+++ b/enclone_tail/src/polygon.rs
@@ -3,10 +3,10 @@
 // Code for working with polygons.  Possibly rename to planar_objects.rs.
 
 use core::mem::swap;
-use float_ord::*;
+use float_ord::FloatOrd;
 use std::f64::consts::PI;
 use superslice::Ext;
-use vector_utils::*;
+use vector_utils::unique_sort;
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 //
@@ -175,7 +175,7 @@ impl IntervalVec {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pretty_trace::*;
+    use pretty_trace::PrettyTrace;
     #[test]
     fn test_interval_vec() {
         PrettyTrace::new().on();

--- a/enclone_tail/src/print_stats.rs
+++ b/enclone_tail/src/print_stats.rs
@@ -658,7 +658,7 @@ pub fn print_stats(
                 for x in cluster.iter() {
                     ncells[x.1 - 1] += 1;
                     let bc = &x.0;
-                    let typex = &cell_type[bc.clone()];
+                    let typex = &cell_type[*bc];
                     if ctl.gen_opt.bcr && typex.starts_with('B') {
                         ncells_type[x.1 - 1] += 1;
                     } else if ctl.gen_opt.tcr && typex.starts_with('T') {
@@ -764,10 +764,8 @@ pub fn print_stats(
                         } else if typex == "r" {
                             if !gex_info.feature_metrics[i]
                                 .contains_key(&(feature.clone(), "num_reads".to_string()))
-                            {
-                                value = "undefined".to_string();
-                            } else if !gex_info.feature_metrics[i]
-                                .contains_key(&(feature.clone(), "num_reads_cells".to_string()))
+                                || !gex_info.feature_metrics[i]
+                                    .contains_key(&(feature.clone(), "num_reads_cells".to_string()))
                             {
                                 value = "undefined".to_string();
                             } else {

--- a/enclone_tail/src/print_stats.rs
+++ b/enclone_tail/src/print_stats.rs
@@ -2,19 +2,19 @@
 
 // Print statistics.
 
-use crate::alluvial_fb::*;
-use enclone_core::defs::*;
-use enclone_core::median::*;
-use io_utils::*;
-use perf_stats::*;
-use stats_utils::*;
+use crate::alluvial_fb::alluvial_fb;
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype, GexInfo};
+use enclone_core::median::median;
+use io_utils::{fwrite, fwriteln};
+use perf_stats::{elapsed, peak_mem_usage_gb};
+use stats_utils::percent_ratio;
 use std::cmp::max;
 use std::collections::HashMap;
 use std::io::Write;
 use std::time::Instant;
-use string_utils::*;
-use tables::*;
-use vector_utils::*;
+use string_utils::{add_commas, TextUtils};
+use tables::print_tabular_vbox;
+use vector_utils::{make_freq, next_diff, next_diff1_2};
 
 pub fn print_stats(
     tall: &Instant,

--- a/enclone_tail/src/requirements.rs
+++ b/enclone_tail/src/requirements.rs
@@ -2,7 +2,7 @@
 
 // Test requirements.
 
-use enclone_core::defs::*;
+use enclone_core::defs::{EncloneControl, ExactClonotype};
 
 pub fn test_requirements(
     pics: &Vec<String>,

--- a/enclone_tail/src/sim_mat_plot.rs
+++ b/enclone_tail/src/sim_mat_plot.rs
@@ -2,13 +2,13 @@
 //
 // Execute SIM_MAT_PLOT.
 
-use enclone_core::defs::*;
-use io_utils::*;
+use enclone_core::defs::EncloneControl;
+use io_utils::{fwrite, open_for_write_new};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufWriter, Write};
-use string_utils::*;
-use tables::*;
+use string_utils::{stringme, TextUtils};
+use tables::print_tabular;
 
 fn hex(c: u8) -> String {
     let x1 = c / 16;

--- a/enclone_tail/src/string_width.rs
+++ b/enclone_tail/src/string_width.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use vector_utils::*;
+use vector_utils::bin_position1_2;
 
 // Estimate the width in pixels of an Arial string at a given font size.
 // This uses a hardcoded table of widths of Arial 1000 point characters.  The table

--- a/enclone_tail/src/tail.rs
+++ b/enclone_tail/src/tail.rs
@@ -2,21 +2,21 @@
 
 // Group and print clonotypes.  For now, limited grouping functionality.
 
-use crate::group::*;
-use enclone_core::defs::*;
-use enclone_core::median::*;
-use enclone_proto::types::*;
-use io_utils::*;
+use crate::group::group_and_print_clonotypes;
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype, GexInfo};
+use enclone_core::median::median_f64;
+use enclone_proto::types::DonorReferenceItem;
+use io_utils::fwrite;
 use ndarray::s;
 use rayon::prelude::*;
 use std::cmp::min;
 use std::collections::HashMap;
 use std::io::Write;
 use std::time::Instant;
-use string_utils::*;
-use tables::*;
-use vdj_ann::refx::*;
-use vector_utils::*;
+use string_utils::{strme, TextUtils};
+use tables::print_tabular;
+use vdj_ann::refx::RefData;
+use vector_utils::bin_position;
 
 pub fn tail_code(
     tall: &Instant,

--- a/enclone_tail/src/ticks.rs
+++ b/enclone_tail/src/ticks.rs
@@ -8,7 +8,7 @@
 //
 // Searching the internet for tick marks algorithm yields some other methods.
 
-use string_utils::*;
+use string_utils::strme;
 
 // Given x ≠ 0, find r and s such that x = r * 10^s, and 1.0 <= |r| < 10.
 
@@ -148,7 +148,7 @@ pub fn ticks(low: f32, high: f32, max_ticks: usize, verbose: bool) -> Vec<String
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pretty_trace::*;
+    use pretty_trace::PrettyTrace;
     #[test]
     fn test_ticks() {
         PrettyTrace::new().on();

--- a/enclone_tail/src/tree.rs
+++ b/enclone_tail/src/tree.rs
@@ -2,12 +2,12 @@
 
 // Generate experimental tree output (options NEWICK0 and TREE).
 
-use crate::display_tree::*;
-use crate::neighbor::*;
-use crate::newick::*;
-use enclone_core::defs::*;
+use crate::display_tree::display_tree;
+use crate::neighbor::neighbor_joining;
+use crate::newick::newick;
+use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype};
 use enclone_proto::types::DonorReferenceItem;
-use io_utils::*;
+use io_utils::{fwrite, fwriteln};
 use std::cmp::max;
 use std::collections::HashMap;
 use std::io::Write;

--- a/enclone_tools/src/bin/cargo_update_safe.rs
+++ b/enclone_tools/src/bin/cargo_update_safe.rs
@@ -132,11 +132,10 @@ fn main() {
             }
             let out = strme(&o.stdout);
             let mut new = String::new();
-            for line in out.lines() {
+            if let Some(line) = out.lines().next() {
                 let c = line.before(" =");
                 assert_eq!(c, cratex);
                 new = line.between("\"", "\"").to_string();
-                break;
             }
             let old_dots = old.matches('.').count();
             let mut new_dots = new.matches('.').count();

--- a/enclone_tools/src/bin/cargo_update_safe.rs
+++ b/enclone_tools/src/bin/cargo_update_safe.rs
@@ -9,15 +9,15 @@
 // * Updates crates even if they have changed very recently.
 // * Should check that results are unchanged.
 
-use io_utils::*;
-use perf_stats::*;
-use pretty_trace::*;
+use io_utils::{fwriteln, open_for_read, open_for_write_new, path_exists};
+use perf_stats::elapsed;
+use pretty_trace::PrettyTrace;
 use std::collections::HashMap;
 use std::fs::{read_dir, File};
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::process::Command;
 use std::time::Instant;
-use string_utils::*;
+use string_utils::{strme, TextUtils};
 
 fn print_dot(dots: &mut usize) {
     if *dots > 0 && *dots % 10 == 0 {

--- a/enclone_tools/src/bin/display_csv.rs
+++ b/enclone_tools/src/bin/display_csv.rs
@@ -4,12 +4,12 @@
 //
 // This can be used to examine the output of POUT.
 
-use io_utils::*;
-use pretty_trace::*;
+use io_utils::open_for_read;
+use pretty_trace::PrettyTrace;
 use std::env;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
-use string_utils::*;
+use string_utils::parse_csv;
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone_tools/src/bin/import_data.rs
+++ b/enclone_tools/src/bin/import_data.rs
@@ -15,20 +15,22 @@
 //
 // For use at 10x Genomics.
 
-use enclone_core::defs::*;
-use enclone_core::testlist::*;
-use enclone_tools::copy_for_enclone::*;
-use enclone_tools::feature_barcode_matrix::*;
-use io_utils::*;
+use enclone_core::defs::get_config;
+use enclone_core::testlist::TEST_FILES_VERSION;
+use enclone_tools::copy_for_enclone::copy_for_enclone;
+use enclone_tools::feature_barcode_matrix::{
+    feature_barcode_matrix, feature_barcode_matrix_seq_def, SequencingDef,
+};
+use io_utils::{fwriteln, open_for_read, open_for_write_new, path_exists};
 use mirror_sparse_matrix::write_to_file;
-use pretty_trace::*;
+use pretty_trace::PrettyTrace;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::env;
 use std::fs::{copy, remove_dir_all, rename, File};
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::process::Command;
-use string_utils::*;
+use string_utils::{parse_csv, TextUtils};
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone_tools/src/bin/merge_html.rs
+++ b/enclone_tools/src/bin/merge_html.rs
@@ -4,19 +4,19 @@
 //
 // If supplied the single argument BUILD, also rebuild from source.
 
+use enclone_core::parse_bsv;
 use enclone_core::testlist::SITE_EXAMPLES;
-use enclone_core::*;
-use enclone_tools::html::*;
-use io_utils::*;
+use enclone_tools::html::{edit_html, insert_html};
+use io_utils::{fwrite, open_for_read, open_for_write_new};
 use itertools::Itertools;
-use pretty_trace::*;
+use pretty_trace::PrettyTrace;
 use rayon::prelude::*;
 use std::env;
 use std::fs::{read_dir, File};
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::process::Command;
-use string_utils::*;
-use vector_utils::*;
+use string_utils::{strme, TextUtils};
+use vector_utils::{bin_member, unique_sort};
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone_tools/src/bin/review_main_tests.rs
+++ b/enclone_tools/src/bin/review_main_tests.rs
@@ -6,9 +6,9 @@
 // NOTE: you have to run this from the enclone_main directory.  Otherwise it won't work.
 
 use enclone::misc1::setup_pager;
-use enclone_core::main_testlist::*;
-use enclone_tools::run_test::*;
-use pretty_trace::*;
+use enclone_core::main_testlist::TESTS;
+use enclone_tools::run_test::run_test;
+use pretty_trace::PrettyTrace;
 use rayon::prelude::*;
 
 fn main() {

--- a/enclone_tools/src/bin/run_last_test.rs
+++ b/enclone_tools/src/bin/run_last_test.rs
@@ -4,9 +4,9 @@
 //
 // Note that this gives the wrong answer if you haven't run ./build first.
 
-use enclone_core::main_testlist::*;
-use enclone_tools::run_test::*;
-use pretty_trace::*;
+use enclone_core::main_testlist::TESTS;
+use enclone_tools::run_test::run_test;
+use pretty_trace::PrettyTrace;
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone_tools/src/bin/update_all_main_tests.rs
+++ b/enclone_tools/src/bin/update_all_main_tests.rs
@@ -7,10 +7,10 @@
 //
 // NOTE: you have to run this from the enclone_main directory.  Otherwise it won't work.
 
-use enclone_core::main_testlist::*;
-use enclone_tools::run_test::*;
-use io_utils::*;
-use pretty_trace::*;
+use enclone_core::main_testlist::TESTS;
+use enclone_tools::run_test::run_test;
+use io_utils::{fwrite, open_for_write_new};
+use pretty_trace::PrettyTrace;
 use rayon::prelude::*;
 use std::fs::File;
 use std::io::{BufWriter, Write};

--- a/enclone_tools/src/copy_for_enclone.rs
+++ b/enclone_tools/src/copy_for_enclone.rs
@@ -3,12 +3,12 @@
 // Copy a 10x pipestance, retaining only the files used by enclone, or which might otherwise
 // be convenient to keep.
 
-use enclone_core::slurp::*;
-use io_utils::*;
+use enclone_core::slurp::slurp_h5;
+use io_utils::{dir_list, path_exists};
 use lz4::EncoderBuilder;
-use mirror_sparse_matrix::*;
+use mirror_sparse_matrix::{write_to_file, MirrorSparseMatrix};
 use std::fs::{copy, remove_file, File};
-use vector_utils::*;
+use vector_utils::VecUtils;
 
 fn copy_file(f: &str, dir1: &str, dir2: &str) {
     let x = copy(&format!("{}/{}", dir1, f), &format!("{}/{}", dir2, f));

--- a/enclone_tools/src/feature_barcode_matrix.rs
+++ b/enclone_tools/src/feature_barcode_matrix.rs
@@ -11,12 +11,12 @@
 // 6. List the barcodes in order by frequency.
 
 use enclone_core::defs::get_config;
-use enclone_core::*;
+use enclone_core::fetch_url;
 use flate2::read::MultiGzDecoder;
-use io_utils::*;
+use io_utils::{dir_list, path_exists};
 use itertools::Itertools;
-use mirror_sparse_matrix::*;
-use perf_stats::*;
+use mirror_sparse_matrix::MirrorSparseMatrix;
+use perf_stats::elapsed;
 use rayon::prelude::*;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -25,8 +25,8 @@ use std::fs;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::time::Instant;
-use string_utils::*;
-use vector_utils::*;
+use string_utils::{stringme, strme, TextUtils};
+use vector_utils::{bin_member, bin_position, make_freq, next_diff12_3, next_diff1_3, sort_sync2};
 
 pub struct SequencingDef {
     pub read_path: String,

--- a/enclone_tools/src/html.rs
+++ b/enclone_tools/src/html.rs
@@ -3,13 +3,13 @@
 // Utility for inserting html files.  It also changes all instances of #enclone to
 // a preset format for that.
 
-use enclone_core::defs::*;
-use io_utils::*;
-use stats_utils::*;
+use enclone_core::defs::HELP_PAGES;
+use io_utils::{fwrite, fwriteln, open_for_read, open_for_write_new};
+use stats_utils::percent_ratio;
 use std::env;
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
-use string_utils::*;
+use string_utils::{add_commas, TextUtils};
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_tools/src/run_test.rs
+++ b/enclone_tools/src/run_test.rs
@@ -1,15 +1,15 @@
 // Copyright (c) 2021 10X Genomics, Inc. All rights reserved.
 
-use ansi_escape::*;
+use ansi_escape::{emit_bold_escape, emit_end_escape};
 use enclone_core::parse_bsv;
-use enclone_core::testlist::*;
-use io_utils::*;
+use enclone_core::testlist::TEST_FILES_VERSION;
+use io_utils::{fwrite, fwriteln, path_exists};
 use itertools::Itertools;
 use std::cmp::min;
 use std::fs::read_to_string;
 use std::io::Write;
 use std::process::Command;
-use string_utils::*;
+use string_utils::{stringme, strme};
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 

--- a/enclone_vars/src/bin/var_sort.rs
+++ b/enclone_vars/src/bin/var_sort.rs
@@ -2,8 +2,8 @@
 
 // Sort and replace the vars file.
 
-use enclone_vars::*;
-use pretty_trace::*;
+use enclone_vars::sort_vars;
+use pretty_trace::PrettyTrace;
 use std::io::Write;
 
 fn main() {

--- a/enclone_vars/src/bin/var_test.rs
+++ b/enclone_vars/src/bin/var_test.rs
@@ -2,8 +2,8 @@
 
 // Parse the vars file to test if it's valid.
 
-use enclone_vars::var::*;
-use pretty_trace::*;
+use enclone_vars::var::parse_variables;
+use pretty_trace::PrettyTrace;
 
 fn main() {
     PrettyTrace::new().on();

--- a/enclone_vars/src/lib.rs
+++ b/enclone_vars/src/lib.rs
@@ -2,8 +2,8 @@
 
 pub mod var;
 
-use string_utils::*;
-use vector_utils::*;
+use string_utils::TextUtils;
+use vector_utils::sort_sync2;
 
 pub fn sort_vars(input: &str) -> String {
     let mut preamble = String::new();

--- a/enclone_vars/src/var.rs
+++ b/enclone_vars/src/var.rs
@@ -2,7 +2,7 @@
 
 // Variable specification.  Fields are currently Strings, but could be given more structure.
 
-use string_utils::*;
+use string_utils::{stringme, TextUtils};
 
 pub struct Variable {
     pub name: String,

--- a/enclone_version/src/lib.rs
+++ b/enclone_version/src/lib.rs
@@ -5,7 +5,7 @@
 use chrono::prelude::*;
 use std::env::consts::{ARCH, OS};
 use std::process::Command;
-use string_utils::*;
+use string_utils::TextUtils;
 
 #[cfg(debug_assertions)]
 const BUILD_TYPE: &str = "debug";


### PR DESCRIPTION
We should probably enable clippy as a github action.  But first we'd have to fix all of the lints.  This just fixes the ones that can be fixed automatically (that is, `clippy` is sure that there's no behavioral change in the code beyond performance and possibly error-prone behavior).  There's lots more, but it's easier to address those once the automatable ones are out of the way.