### PR TITLE
Update hdf5 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2415,7 +2415,7 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 [[package]]
 name = "hdf5"
 version = "0.7.1"
-source = "git+https://github.com/10xGenomics/hdf5-rust.git?rev=2c5db3f4f081fa4857509cf1770126ae3cd9c426#2c5db3f4f081fa4857509cf1770126ae3cd9c426"
+source = "git+https://github.com/10xGenomics/hdf5-rust.git?rev=ee3e4fa681abc439d64ce5720fba0c8c819eebdb#ee3e4fa681abc439d64ce5720fba0c8c819eebdb"
 dependencies = [
  "bitflags",
  "hdf5-derive",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "hdf5-derive"
 version = "0.7.1"
-source = "git+https://github.com/10xGenomics/hdf5-rust.git?rev=2c5db3f4f081fa4857509cf1770126ae3cd9c426#2c5db3f4f081fa4857509cf1770126ae3cd9c426"
+source = "git+https://github.com/10xGenomics/hdf5-rust.git?rev=ee3e4fa681abc439d64ce5720fba0c8c819eebdb#ee3e4fa681abc439d64ce5720fba0c8c819eebdb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2441,7 +2441,7 @@ dependencies = [
 [[package]]
 name = "hdf5-sys"
 version = "0.7.1"
-source = "git+https://github.com/10xGenomics/hdf5-rust.git?rev=2c5db3f4f081fa4857509cf1770126ae3cd9c426#2c5db3f4f081fa4857509cf1770126ae3cd9c426"
+source = "git+https://github.com/10xGenomics/hdf5-rust.git?rev=ee3e4fa681abc439d64ce5720fba0c8c819eebdb#ee3e4fa681abc439d64ce5720fba0c8c819eebdb"
 dependencies = [
  "attohttpc",
  "bzip2",
@@ -2459,7 +2459,7 @@ dependencies = [
 [[package]]
 name = "hdf5-types"
 version = "0.7.1"
-source = "git+https://github.com/10xGenomics/hdf5-rust.git?rev=2c5db3f4f081fa4857509cf1770126ae3cd9c426#2c5db3f4f081fa4857509cf1770126ae3cd9c426"
+source = "git+https://github.com/10xGenomics/hdf5-rust.git?rev=ee3e4fa681abc439d64ce5720fba0c8c819eebdb#ee3e4fa681abc439d64ce5720fba0c8c819eebdb"
 dependencies = [
  "ascii",
  "libc",

--- a/enclone/Cargo.toml
+++ b/enclone/Cargo.toml
@@ -27,7 +27,7 @@ enclone_core = { path = "../enclone_core" }
 equiv = "0.1"
 evalexpr = "6"
 graph_simple = "0.1"
-hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "2c5db3f4f081fa4857509cf1770126ae3cd9c426", default-features=false, features = ["conda"] }
+hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "ee3e4fa681abc439d64ce5720fba0c8c819eebdb", default-features=false, features = ["conda", "const_generics"] }
 io_utils = "0.2"
 itertools = "0.10"
 mirror_sparse_matrix = "0.1"

--- a/enclone_args/Cargo.toml
+++ b/enclone_args/Cargo.toml
@@ -27,7 +27,7 @@ attohttpc = { version = "0.17", default-features = false, features = ["compress"
 debruijn = "0.3"
 enclone_core = { path = "../enclone_core" }
 evalexpr = "6"
-hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "2c5db3f4f081fa4857509cf1770126ae3cd9c426", default-features=false, features = ["conda"] }
+hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "ee3e4fa681abc439d64ce5720fba0c8c819eebdb", default-features=false, features = ["conda", "const_generics"] }
 io_utils = "0.2"
 itertools = "0.10"
 mirror_sparse_matrix = "0.1"

--- a/enclone_core/Cargo.toml
+++ b/enclone_core/Cargo.toml
@@ -29,7 +29,7 @@ chrono = { version = "0.4", default-features = false, features = ["std", "clock"
 debruijn = "0.3"
 enclone_proto = { path = "../enclone_proto" }
 evalexpr = "6"
-hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "2c5db3f4f081fa4857509cf1770126ae3cd9c426", default-features=false, features = ["conda"] }
+hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "ee3e4fa681abc439d64ce5720fba0c8c819eebdb", default-features=false, features = ["conda", "const_generics"] }
 io_utils = "0.2"
 itertools = "0.10"
 lazy_static = "1"

--- a/enclone_main/Cargo.toml
+++ b/enclone_main/Cargo.toml
@@ -29,7 +29,7 @@ enclone_stuff = { path = "../enclone_stuff" }
 enclone_tail = { path = "../enclone_tail" }
 enclone = { path = "../enclone" }
 enclone_args = { path = "../enclone_args" }
-hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "2c5db3f4f081fa4857509cf1770126ae3cd9c426", default-features=false, features = ["conda"] }
+hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "ee3e4fa681abc439d64ce5720fba0c8c819eebdb", default-features=false, features = ["conda", "const_generics"] }
 io_utils = "0.2"
 itertools = "0.10"
 perf_stats = "0.1"

--- a/enclone_print/Cargo.toml
+++ b/enclone_print/Cargo.toml
@@ -32,7 +32,7 @@ enclone_args = { path = "../enclone_args" }
 enclone_core = { path = "../enclone_core" }
 enclone_proto = { path = "../enclone_proto" }
 equiv = "0.1"
-hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "2c5db3f4f081fa4857509cf1770126ae3cd9c426", default-features=false, features = ["conda"] }
+hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "ee3e4fa681abc439d64ce5720fba0c8c819eebdb", default-features=false, features = ["conda", "const_generics"] }
 io_utils = "0.2"
 itertools = "0.10"
 mirror_sparse_matrix = "0.1"

--- a/enclone_ranger/Cargo.toml
+++ b/enclone_ranger/Cargo.toml
@@ -26,7 +26,7 @@ enclone_proto = { path = "../enclone_proto" }
 enclone_stuff = { path = "../enclone_stuff" }
 enclone = { path = "../enclone" }
 enclone_args = { path = "../enclone_args" }
-hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "2c5db3f4f081fa4857509cf1770126ae3cd9c426", default-features=false, features = ["conda"] }
+hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "ee3e4fa681abc439d64ce5720fba0c8c819eebdb", default-features=false, features = ["conda", "const_generics"] }
 io_utils = "0.2"
 itertools = "0.10"
 rayon = "1"

--- a/enclone_stuff/Cargo.toml
+++ b/enclone_stuff/Cargo.toml
@@ -28,7 +28,7 @@ enclone = { path = "../enclone" }
 enclone_args = { path = "../enclone_args" }
 equiv = "0.1"
 evalexpr = "6"
-hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "2c5db3f4f081fa4857509cf1770126ae3cd9c426", default-features=false, features = ["conda"] }
+hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "ee3e4fa681abc439d64ce5720fba0c8c819eebdb", default-features=false, features = ["conda", "const_generics"] }
 io_utils = "0.2"
 itertools = "0.10"
 ndarray = ">=0.14, <0.16"

--- a/enclone_tail/Cargo.toml
+++ b/enclone_tail/Cargo.toml
@@ -34,7 +34,7 @@ enclone_proto = { path = "../enclone_proto" }
 equiv = "0.1"
 float-ord = "0.3"
 fontdb = "0.6"
-hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "2c5db3f4f081fa4857509cf1770126ae3cd9c426", default-features=false, features = ["conda"] }
+hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "ee3e4fa681abc439d64ce5720fba0c8c819eebdb", default-features=false, features = ["conda", "const_generics"] }
 io_utils = "0.2"
 itertools = "0.10"
 lazy_static = "1"

--- a/enclone_tools/Cargo.toml
+++ b/enclone_tools/Cargo.toml
@@ -28,7 +28,7 @@ enclone_core = { path = "../enclone_core" }
 evalexpr = "6"
 flate2 = "1"
 fs_extra = "1"
-hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "2c5db3f4f081fa4857509cf1770126ae3cd9c426", default-features=false, features = ["conda"] }
+hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "ee3e4fa681abc439d64ce5720fba0c8c819eebdb", default-features=false, features = ["conda", "const_generics"] }
 io_utils = "0.2"
 itertools = "0.10"
 lz4 = "1"

--- a/master.toml
+++ b/master.toml
@@ -46,7 +46,7 @@ fontdb = "0.6"
 fs_extra = "1"
 git = "https://github.com/10xGenomics/hdf5-rust.git"
 graph_simple = "0.1"
-hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "2c5db3f4f081fa4857509cf1770126ae3cd9c426", default-features=false, features = ["conda"] }
+hdf5 = { git = "https://github.com/10xGenomics/hdf5-rust.git", rev = "ee3e4fa681abc439d64ce5720fba0c8c819eebdb", default-features=false, features = ["conda", "const_generics"] }
 iced = { git = "https://github.com/hecrj/iced", rev = "569aff331f4fd4e9ead1866f56a8a7170de4b7a5", features = ["canvas", "image", "async-std"] }
 iced_native = { git = "https://github.com/hecrj/iced", rev = "569aff331f4fd4e9ead1866f56a8a7170de4b7a5" }
 image = { version = "0.23", features = ["jpeg", "png", "jpeg_rayon"], default-features = false }


### PR DESCRIPTION
Fairly [small change in rust-hdf5](https://github.com/10XGenomics/hdf5-rust/commit/ee3e4fa681abc439d64ce5720fba0c8c819eebdb), allowing the use of const generics for larger fixed size arrays.