### PR TITLE
Bump vdj_ann version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,6 +1356,7 @@ dependencies = [
  "stats_utils",
  "string_utils",
  "vdj_ann",
+ "vdj_ann_ref",
  "vector_utils",
 ]
 
@@ -1437,6 +1438,7 @@ dependencies = [
  "superslice",
  "tables",
  "vdj_ann",
+ "vdj_ann_ref",
  "vector_utils",
 ]
 
@@ -1507,6 +1509,7 @@ dependencies = [
  "string_utils",
  "tilde-expand",
  "vdj_ann",
+ "vdj_ann_ref",
  "vector_utils",
 ]
 
@@ -5243,28 +5246,40 @@ dependencies = [
 [[package]]
 name = "vdj_ann"
 version = "0.1.6"
-source = "git+https://github.com/10XGenomics/rust-toolbox.git?rev=3ebbdfe8c1b441dd58aa3e4095a79f5e62a56515#3ebbdfe8c1b441dd58aa3e4095a79f5e62a56515"
+source = "git+https://github.com/10XGenomics/rust-toolbox.git?rev=3fb29bd1d46c12df08c686ac2d7c70b969bf017a#3fb29bd1d46c12df08c686ac2d7c70b969bf017a"
 dependencies = [
  "align_tools",
  "amino",
  "bio_edit",
  "debruijn",
- "exons",
  "fasta_tools",
- "flate2",
  "hyperbase",
  "io_utils",
  "itertools",
  "kmer_lookup",
- "pretty_trace",
  "serde",
  "serde_json",
- "sha2",
  "stats_utils",
  "string_utils",
- "strum",
- "strum_macros",
  "vdj_types",
+ "vector_utils",
+]
+
+[[package]]
+name = "vdj_ann_ref"
+version = "0.1.6"
+source = "git+https://github.com/10XGenomics/rust-toolbox.git?rev=3fb29bd1d46c12df08c686ac2d7c70b969bf017a#3fb29bd1d46c12df08c686ac2d7c70b969bf017a"
+dependencies = [
+ "debruijn",
+ "exons",
+ "fasta_tools",
+ "flate2",
+ "io_utils",
+ "kmer_lookup",
+ "pretty_trace",
+ "sha2",
+ "string_utils",
+ "vdj_ann",
  "vector_utils",
 ]
 

--- a/enclone/Cargo.toml
+++ b/enclone/Cargo.toml
@@ -42,7 +42,8 @@ serde_derive = "1"
 serde_json = "1"
 stats_utils = "0.1"
 string_utils = "0.1"
-vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3ebbdfe8c1b441dd58aa3e4095a79f5e62a56515" }
+vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3fb29bd1d46c12df08c686ac2d7c70b969bf017a" }
+vdj_ann_ref = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3fb29bd1d46c12df08c686ac2d7c70b969bf017a" }
 vector_utils = "0.1"
 
 [dev-dependencies]

--- a/enclone/src/innate.rs
+++ b/enclone/src/innate.rs
@@ -8,7 +8,8 @@
 
 use enclone_core::defs::ExactClonotype;
 use string_utils::TextUtils;
-use vdj_ann::refx::{human_ref, mouse_ref, RefData};
+use vdj_ann::refx::RefData;
+use vdj_ann_ref::{human_ref, mouse_ref};
 use vector_utils::{bin_member, reverse_sort, unique_sort};
 
 pub fn species(refdata: &RefData) -> String {

--- a/enclone_args/Cargo.toml
+++ b/enclone_args/Cargo.toml
@@ -36,5 +36,5 @@ regex = { version = "1", default-features = false, features = ["std", "perf"] }
 serde_json = "1"
 string_utils = "0.1"
 tilde-expand = "0.1"
-vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3ebbdfe8c1b441dd58aa3e4095a79f5e62a56515" }
+vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3fb29bd1d46c12df08c686ac2d7c70b969bf017a" }
 vector_utils = "0.1"

--- a/enclone_com/Cargo.toml
+++ b/enclone_com/Cargo.toml
@@ -27,4 +27,4 @@ lazy_static = "1"
 pretty_trace = "0.5"
 string_utils = "0.1"
 tokio = { version = "1", default-features = false, features = ["io-util", "macros", "rt-multi-thread"] }
-vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3ebbdfe8c1b441dd58aa3e4095a79f5e62a56515" }
+vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3fb29bd1d46c12df08c686ac2d7c70b969bf017a" }

--- a/enclone_core/Cargo.toml
+++ b/enclone_core/Cargo.toml
@@ -42,7 +42,7 @@ stirling_numbers = "0.1"
 string_utils = "0.1"
 superslice = "1"
 tables = "0.1"
-vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3ebbdfe8c1b441dd58aa3e4095a79f5e62a56515" }
+vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3fb29bd1d46c12df08c686ac2d7c70b969bf017a" }
 vector_utils = "0.1"
 zstd = "0.9"
 

--- a/enclone_denovo/Cargo.toml
+++ b/enclone_denovo/Cargo.toml
@@ -39,5 +39,6 @@ stats_utils = "0.1"
 string_utils = "0.1"
 superslice = "1"
 tables = "0.1"
-vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3ebbdfe8c1b441dd58aa3e4095a79f5e62a56515" }
+vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3fb29bd1d46c12df08c686ac2d7c70b969bf017a" }
+vdj_ann_ref = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3fb29bd1d46c12df08c686ac2d7c70b969bf017a" }
 vector_utils = "0.1"

--- a/enclone_denovo/src/bin/denovo.rs
+++ b/enclone_denovo/src/bin/denovo.rs
@@ -165,7 +165,7 @@ use std::io::{BufWriter, Write};
 use std::process::Command;
 use string_utils::{add_commas, stringme, strme, TextUtils};
 use superslice::Ext;
-use vdj_ann::refx::{human_ref, mouse_ref};
+use vdj_ann_ref::{human_ref, mouse_ref};
 use vector_utils::{bin_member, bin_position, erase_if, reverse_sort, sort_sync2, unique_sort};
 
 // copied from tenkit2/pack_dna.rs:

--- a/enclone_exec/tests/enclone_test2.rs
+++ b/enclone_exec/tests/enclone_test2.rs
@@ -511,7 +511,6 @@ fn test_internal() {
 #[cfg(not(feature = "cpu"))]
 #[test]
 fn test_for_broken_links_and_spellcheck() {
-    extern crate attohttpc;
     use std::time::Duration;
 
     // Set up link exceptions.  These are links that have been observed to break periodically.

--- a/enclone_main/Cargo.toml
+++ b/enclone_main/Cargo.toml
@@ -39,5 +39,6 @@ serde_json = "1"
 stats_utils = "0.1"
 string_utils = "0.1"
 tilde-expand = "0.1"
-vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3ebbdfe8c1b441dd58aa3e4095a79f5e62a56515" }
+vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3fb29bd1d46c12df08c686ac2d7c70b969bf017a" }
+vdj_ann_ref = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3fb29bd1d46c12df08c686ac2d7c70b969bf017a" }
 vector_utils = "0.1"

--- a/enclone_main/src/determine_ref.rs
+++ b/enclone_main/src/determine_ref.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use string_utils::{strme, TextUtils};
-use vdj_ann::refx::{
+use vdj_ann_ref::{
     human_ref, human_ref_2_0, human_ref_3_1, human_ref_4_0, mouse_ref, mouse_ref_3_1, mouse_ref_4_0,
 };
 use vector_utils::{erase_if, unique_sort, VecUtils};

--- a/enclone_print/Cargo.toml
+++ b/enclone_print/Cargo.toml
@@ -47,5 +47,5 @@ serde_json = "1"
 stats_utils = "0.1"
 string_utils = "0.1"
 tables = "0.1"
-vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3ebbdfe8c1b441dd58aa3e4095a79f5e62a56515" }
+vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3fb29bd1d46c12df08c686ac2d7c70b969bf017a" }
 vector_utils = "0.1"

--- a/enclone_proto/Cargo.toml
+++ b/enclone_proto/Cargo.toml
@@ -25,7 +25,7 @@ prost = { version = "0.8", default_features = false }
 serde = "1"
 serde_derive = "1"
 thiserror = "1"
-vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3ebbdfe8c1b441dd58aa3e4095a79f5e62a56515" }
+vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3fb29bd1d46c12df08c686ac2d7c70b969bf017a" }
 
 [build-dependencies]
 prost-build = "0.8"

--- a/enclone_ranger/Cargo.toml
+++ b/enclone_ranger/Cargo.toml
@@ -31,5 +31,5 @@ io_utils = "0.2"
 itertools = "0.10"
 rayon = "1"
 string_utils = "0.1"
-vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3ebbdfe8c1b441dd58aa3e4095a79f5e62a56515" }
+vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3fb29bd1d46c12df08c686ac2d7c70b969bf017a" }
 vector_utils = "0.1"

--- a/enclone_stuff/Cargo.toml
+++ b/enclone_stuff/Cargo.toml
@@ -38,5 +38,5 @@ stats_utils = "0.1"
 stirling_numbers = "0.1"
 string_utils = "0.1"
 tables = "0.1"
-vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3ebbdfe8c1b441dd58aa3e4095a79f5e62a56515" }
+vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3fb29bd1d46c12df08c686ac2d7c70b969bf017a" }
 vector_utils = "0.1"

--- a/enclone_tail/Cargo.toml
+++ b/enclone_tail/Cargo.toml
@@ -55,7 +55,7 @@ tables = "0.1"
 tar = "0.4"
 tiny-skia = "0.6"
 usvg = { version = "0.17", features = ["text"] }
-vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3ebbdfe8c1b441dd58aa3e4095a79f5e62a56515" }
+vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3fb29bd1d46c12df08c686ac2d7c70b969bf017a" }
 vector_utils = "0.1"
 # to replace by this after bumping version
 # vector_utils = "0.1.0"

--- a/enclone_tools/Cargo.toml
+++ b/enclone_tools/Cargo.toml
@@ -41,5 +41,5 @@ regex = { version = "1", default-features = false, features = ["std", "perf"] }
 serde_json = "1"
 stats_utils = "0.1"
 string_utils = "0.1"
-vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3ebbdfe8c1b441dd58aa3e4095a79f5e62a56515" }
+vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3fb29bd1d46c12df08c686ac2d7c70b969bf017a" }
 vector_utils = "0.1"

--- a/master.toml
+++ b/master.toml
@@ -97,6 +97,7 @@ tonic = { version = "0.5", default-features = false, features = ["transport", "c
 tonic-build = { version = "0.5", default-features = false, features = ["transport", "prost"] }
 users = "0.11"
 usvg = { version = "0.17", features = ["text"] }
-vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3ebbdfe8c1b441dd58aa3e4095a79f5e62a56515" }
+vdj_ann = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3fb29bd1d46c12df08c686ac2d7c70b969bf017a" }
+vdj_ann_ref = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev = "3fb29bd1d46c12df08c686ac2d7c70b969bf017a" }
 vector_utils = "0.1"
 yaml-rust = "0.4"


### PR DESCRIPTION
This version has some breaking changes, in that it moved the refdata out
of the vdj_ann crate into a separate vdj_ann_ref crate.