### PR TITLE
various changes (= dj/239)

### DIFF
--- a/enclone_denovo/src/const_ighd.rs
+++ b/enclone_denovo/src/const_ighd.rs
@@ -2,6 +2,7 @@
 
 // Code to help find IGHD constant regions.
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use std::arch::x86_64::{
     __m128, __m128i, __m256, _mm256_add_epi32, _mm256_add_ps, _mm256_castps256_ps128,
     _mm256_cvtepu8_epi32, _mm256_extractf128_ps, _mm256_i32gather_ps, _mm256_mullo_epi32,
@@ -39,6 +40,7 @@ fn ighd_score_orig(x: &[u8], u: &Vec<f32>) -> f32 {
     a
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx2")]
 unsafe fn s32_avx2(x: &[u8], u: &Vec<f32>, sub_vec_size: usize) -> f32 {
     let n = u.len() / sub_vec_size;
@@ -73,6 +75,7 @@ unsafe fn s32_avx2(x: &[u8], u: &Vec<f32>, sub_vec_size: usize) -> f32 {
 
 /// Sum the slots in 8xf32 vector
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx2")]
 unsafe fn hsum256_ps_avx(vin: __m256) -> f32 {
     let vlow: __m128 = _mm256_castps256_ps128(vin);

--- a/enclone_denovo/src/const_ighd.rs
+++ b/enclone_denovo/src/const_ighd.rs
@@ -16,9 +16,14 @@ use std::arch::x86_64::{
 pub fn ighd_score(x: &[u8], ighd_pwm2: &Vec<f32>) -> f32 {
     let sub_vec_size = 5;
     let logp;
-    if is_x86_feature_detected!("avx2") {
-        logp = unsafe { s32_avx2(x, ighd_pwm2, sub_vec_size) };
-    } else {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
+        if is_x86_feature_detected!("avx2") {
+            logp = unsafe { s32_avx2(x, ighd_pwm2, sub_vec_size) };
+        } else {
+            logp = ighd_score_orig(x, ighd_pwm2);
+        }
+    }
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))] {
         logp = ighd_score_orig(x, ighd_pwm2);
     }
     logp

--- a/enclone_denovo/src/const_ighd.rs
+++ b/enclone_denovo/src/const_ighd.rs
@@ -17,14 +17,16 @@ use std::arch::x86_64::{
 pub fn ighd_score(x: &[u8], ighd_pwm2: &Vec<f32>) -> f32 {
     let sub_vec_size = 5;
     let logp;
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
         if is_x86_feature_detected!("avx2") {
             logp = unsafe { s32_avx2(x, ighd_pwm2, sub_vec_size) };
         } else {
             logp = ighd_score_orig(x, ighd_pwm2);
         }
     }
-    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))] {
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    {
         logp = ighd_score_orig(x, ighd_pwm2);
     }
     logp

--- a/enclone_visual/src/bin/test_vis.rs
+++ b/enclone_visual/src/bin/test_vis.rs
@@ -544,7 +544,7 @@ fn main() {
                     .expect("failed to execute ssh");
                 let out = strme(&o.stdout);
                 for line in out.lines() {
-                    if line.contains("enclone") {
+                    if line.contains("enclone SERVER") {
                         eprintln!(
                             "\nLooks like you may have a stray process running on the \
                             remote server:\n{}\n\n\

--- a/enclone_visual/src/enclone_client.rs
+++ b/enclone_visual/src/enclone_client.rs
@@ -542,7 +542,7 @@ pub async fn enclone_client(t: &Instant) -> Result<(), Box<dyn std::error::Error
             }
             if remote_id.is_none() {
                 xprintln!("\nUnable to determine remote process id.\n");
-                xprintln!("message = {}", emsg);
+                xprintln!("message =\n\"{}\"", emsg);
                 std::process::exit(1);
             }
             let remote_version;
@@ -552,7 +552,7 @@ pub async fn enclone_client(t: &Instant) -> Result<(), Box<dyn std::error::Error
                 remote_version = emsg.between("enclone version = ", "\n").to_string();
             } else {
                 xprint!("\nUnable to determine remote enclone version.\n");
-                xprintln!("message = {}", emsg);
+                xprintln!("message =\n\"{}\"", emsg);
                 std::process::exit(1);
             }
             let remote_version_string;
@@ -561,7 +561,7 @@ pub async fn enclone_client(t: &Instant) -> Result<(), Box<dyn std::error::Error
                 remote_version_string = emsg.between("version string = ", "\n").to_string();
             } else {
                 xprint!("\nUnable to determine remote version string.\n");
-                xprintln!("message = {}", emsg);
+                xprintln!("message =\n\"{}\"", emsg);
                 std::process::exit(1);
             }
             let local_version = env!("CARGO_PKG_VERSION");

--- a/enclone_visual/src/enclone_server.rs
+++ b/enclone_visual/src/enclone_server.rs
@@ -624,10 +624,18 @@ pub async fn enclone_server() -> Result<(), Box<dyn std::error::Error>> {
     let mut emsg = format!("I am process {}.\n", std::process::id());
     emsg += &mut format!("enclone version = {}\n", env!("CARGO_PKG_VERSION"));
     emsg += &mut format!("version string = {}\n", version);
-    emsg += &mut format!("Welcome!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
-    emsg += &mut format!("Welcome!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
-    emsg += &mut format!("Welcome!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
-    emsg += &mut format!("Welcome!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
+    emsg += &mut format!(
+        "Welcome!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+    );
+    emsg += &mut format!(
+        "Welcome!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+    );
+    emsg += &mut format!(
+        "Welcome!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+    );
+    emsg += &mut format!(
+        "Welcome!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+    );
     eprint!("{}", emsg);
 
     println!("current dir = {}", current_dir);

--- a/enclone_visual/src/enclone_server.rs
+++ b/enclone_visual/src/enclone_server.rs
@@ -612,23 +612,26 @@ pub async fn enclone_server() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    eprintln!("I am process {}.", std::process::id());
-    eprintln!("enclone version = {}", env!("CARGO_PKG_VERSION"));
     let mut version = current_version_string();
     let current_dir = std::env::current_dir()?;
     let current_dir = current_dir.display();
     let current_executable = std::env::current_exe()?;
     let current_executable = current_executable.display();
-    println!("current dir = {}", current_dir);
-    println!("current executable = {}", current_executable);
     if format!("{}", current_executable) == format!("{}/target/debug/enclone", current_dir) {
         version = current_version_string();
     }
-    eprintln!("version string = {}", version);
-    eprintln!("Welcome!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-    eprintln!("Welcome!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-    eprintln!("Welcome!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-    eprintln!("Welcome!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+
+    let mut emsg = format!("I am process {}.\n", std::process::id());
+    emsg += &mut format!("enclone version = {}\n", env!("CARGO_PKG_VERSION"));
+    emsg += &mut format!("version string = {}\n", version);
+    emsg += &mut format!("Welcome!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
+    emsg += &mut format!("Welcome!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
+    emsg += &mut format!("Welcome!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
+    emsg += &mut format!("Welcome!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
+    eprint!("{}", emsg);
+
+    println!("current dir = {}", current_dir);
+    println!("current executable = {}", current_executable);
     Server::builder()
         .add_service(AnalyzerServer::new(analyzer))
         .serve_with_incoming(TcpListenerStream::new(listener))

--- a/test
+++ b/test
@@ -132,7 +132,7 @@ set elapsed = `expr $end - $start`
 ##### FAIL IF TOO MUCH TIME USED #####
 
 echo "\ntest compile time = $compile_elapsed seconds"
-set expected = 155
+set expected = 152
 set fudge_num = 11
 set fudge_den = 10
 set expected_plus_times = `expr $expected \* $fudge_num`


### PR DESCRIPTION
- Make it possible to run test_vis concurrent with remote tests.
- Slightly lower test time.
- Fix some M1 compilation issues.
- Make some error messages more informative.
- Server now sends stderr in one block.
STATUS: ./test, enclone.test and test_vis pass.