### PR TITLE
CI: Use ghcr.io/10xdev/toolchain:latest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
         run: >
           docker run -v ${{github.workspace}}:/root
           -e GITHUB_SHA -e GITHUB_REF -e DEBIAN_FRONTEND=noninteractive
-          docker.pkg.github.com/10xdev/toolchain-scripts/toolchain:latest
+          docker pull ghcr.io/10xdev/toolchain:latest
           /bin/bash -leuxc '
           apt-get update
           && apt-get install -y libfreetype6-dev pkg-config


### PR DESCRIPTION
Use Docker image
    ghcr.io/10xdev/toolchain:latest
rather than
    docker.pkg.github.com/10xdev/toolchain-scripts/toolchain:latest

See https://github.com/10XDev/toolchain-scripts/pkgs/container/toolchain
and https://github.com/10XDev/toolchain-scripts/pkgs/container/toolchain-scripts/toolchain
