### PR TITLE
Limit Threads on Jenkins Builds

### DIFF
--- a/enclone/src/enclone.test
+++ b/enclone/src/enclone.test
@@ -14,6 +14,17 @@
 
 rootdir=$(dirname $0)
 
+# On jenkins build machines, e.g. `jenkins-test-centos610-2` using too many threads appears
+# To lead to contention and slow downs, we should better understand the rules around how
+# we'd wind up in a situation where X threads was too many, but for now we limit to ~14 if
+# on a jenkins machine
+MAX_CORES=""
+cat /proc/sys/kernel/hostname | grep "jenkins"
+if [ $? -eq 0 ]
+then
+   MAX_CORES=8
+fi
+
 enclone \
     BCR=`cat $rootdir/../../enclone_core/src/enclone.testdata | grep -v '#' | tr -d ' ' | grep -v '^$' | head --bytes=-1 | \
         tr '\n' ';' | tr -s ';'` \
@@ -22,6 +33,7 @@ enclone \
     PRE=/mnt/assembly/vdj/current15 \
     MIX_DONORS \
     NOPAGER \
+    $MAX_CORES \
     \
     BUILT_IN \
     \


### PR DESCRIPTION
We observed that the time to run `enclone.test` as part of the CI varied widely between runs.  Profiling showed that on both `bespin` (under load) and on the jenkins build machines, a lot of time seemed to be spent dealing with thread contention.  The circumstantial evidence for this was:

1 - Lots of time spent in the kernal inside `native_queued_spin_lock_slowpath` on bespin runs that were profiled when other jobs were running.
2 - Running `time enclone.test` on both bespin and jenkins boxes, showed the amount of time thejenkins box spent in `systime`:`usertime` was at a >9X ratio, while on faster runs the sys time was a small fraction of the user time (see below)

```
4 Cores bespin
real    18m39.052s
user    67m31.350s
sys     0m29.010s

All cores bespin
real    4m11.926s
user    99m7.788s
sys     12m29.731s

All cores CentOS
real    42m25.036s
user    93m13.377s
sys     895m13.004s

8 cores CentOS
real    14m15.342s
user    76m3.550s
sys     11m39.185s
```

As a result, for now we'll limit the number of threads to avoid the issues that can happen if you try to race 10 Ferrari's on a two lane highway.