### PR TITLE
Run cargo clippy --fix.

### DIFF
--- a/enclone/src/graph_filter.rs
+++ b/enclone/src/graph_filter.rs
@@ -31,7 +31,7 @@ use vector_utils::{bin_member, bin_position, erase_if, lower_bound, next_diff12_
 
 pub fn graph_filter(
     ctl: &EncloneControl,
-    mut tig_bc: &mut Vec<Vec<TigData>>,
+    tig_bc: &mut Vec<Vec<TigData>>,
     graph: bool,
     fate: &mut Vec<HashMap<String, String>>,
 ) {
@@ -386,7 +386,7 @@ pub fn graph_filter(
         }
     }
     if !ctl.gen_opt.ngraph_filter {
-        erase_if(&mut tig_bc, &to_delete);
+        erase_if(tig_bc, &to_delete);
     }
     if graph {
         fwriteln!(log, "");

--- a/enclone/src/join.rs
+++ b/enclone/src/join.rs
@@ -32,7 +32,7 @@ pub fn join_exacts(
     ctl: &EncloneControl,
     exact_clonotypes: &Vec<ExactClonotype>,
     info: &Vec<CloneInfo>,
-    mut join_info: &mut Vec<(usize, usize, bool, Vec<u8>)>,
+    join_info: &mut Vec<(usize, usize, bool, Vec<u8>)>,
     raw_joins: &mut Vec<(i32, i32)>,
     sr: &Vec<Vec<f64>>,
 ) -> EquivRel {
@@ -457,5 +457,5 @@ pub fn join_exacts(
             raw_joins.push((results[l].5[j].0 as i32, results[l].5[j].1 as i32));
         }
     }
-    finish_join(ctl, info, &results, &mut join_info)
+    finish_join(ctl, info, &results, join_info)
 }

--- a/enclone/src/misc1.rs
+++ b/enclone/src/misc1.rs
@@ -194,7 +194,7 @@ pub fn lookup_heavy_chain_reuse(
 
 pub fn cross_filter(
     ctl: &EncloneControl,
-    mut tig_bc: &mut Vec<Vec<TigData>>,
+    tig_bc: &mut Vec<Vec<TigData>>,
     fate: &mut Vec<HashMap<String, String>>,
 ) {
     // Get the list of dataset origins.  Here we allow the same origin name to have been used
@@ -299,5 +299,5 @@ pub fn cross_filter(
             }
         }
     }
-    erase_if(&mut tig_bc, &to_delete);
+    erase_if(tig_bc, &to_delete);
 }

--- a/enclone/src/misc2.rs
+++ b/enclone/src/misc2.rs
@@ -29,7 +29,7 @@ use vector_utils::{
 
 pub fn filter_gelbead_contamination(
     ctl: &EncloneControl,
-    mut clones: &mut Vec<Vec<TigData0>>,
+    clones: &mut Vec<Vec<TigData0>>,
     fate: &mut Vec<(usize, String, String)>,
 ) {
     const GB_UMI_MULT: usize = 10;
@@ -81,7 +81,7 @@ pub fn filter_gelbead_contamination(
         }
     }
     if !ctl.gen_opt.nwhitef {
-        erase_if(&mut clones, &bad);
+        erase_if(clones, &bad);
     }
 }
 

--- a/enclone_args/src/load_gex.rs
+++ b/enclone_args/src/load_gex.rs
@@ -15,7 +15,7 @@ use vector_utils::{bin_position, unique_sort};
 
 // Get gene expression and feature barcoding counts.
 
-pub fn get_gex_info(mut ctl: &mut EncloneControl) -> Result<GexInfo, String> {
+pub fn get_gex_info(ctl: &mut EncloneControl) -> Result<GexInfo, String> {
     let mut gex_features = Vec::<Vec<String>>::new();
     let mut gex_barcodes = Vec::<Vec<String>>::new();
     let mut gex_matrices = Vec::<MirrorSparseMatrix>::new();
@@ -43,7 +43,7 @@ pub fn get_gex_info(mut ctl: &mut EncloneControl) -> Result<GexInfo, String> {
     let mut json_metrics = Vec::<HashMap<String, f64>>::new();
     let mut metrics = Vec::<String>::new();
     load_gex(
-        &mut ctl,
+        ctl,
         &mut gex_features,
         &mut gex_barcodes,
         &mut gex_matrices,

--- a/enclone_args/src/proc_args.rs
+++ b/enclone_args/src/proc_args.rs
@@ -883,7 +883,7 @@ pub fn proc_args(mut ctl: &mut EncloneControl, args: &Vec<String>) -> Result<(),
         }
         process_special_arg(
             &args[i],
-            &mut ctl,
+            ctl,
             &mut metas,
             &mut metaxs,
             &mut xcrs,
@@ -909,7 +909,7 @@ pub fn proc_args(mut ctl: &mut EncloneControl, args: &Vec<String>) -> Result<(),
         );
     }
     proc_args_post(
-        &mut ctl, &args, &metas, &metaxs, &xcrs, have_gex, &gex, &bc, using_plot,
+        ctl, &args, &metas, &metaxs, &xcrs, have_gex, &gex, &bc, using_plot,
     )?;
     Ok(())
 }

--- a/enclone_args/src/proc_args3.rs
+++ b/enclone_args/src/proc_args3.rs
@@ -649,7 +649,7 @@ pub fn proc_xcr(
                 if !bc.is_empty() {
                     bcx = datasets_bc[ix].to_string();
                 }
-                parse_bc(bcx, &mut ctl, "BC")?;
+                parse_bc(bcx, ctl, "BC")?;
             }
         }
     }
@@ -837,7 +837,7 @@ pub fn proc_meta_core(lines: &Vec<String>, mut ctl: &mut EncloneControl) -> Resu
 
             // Parse bc and finish up.
 
-            parse_bc(bc.clone(), &mut ctl, "META")?;
+            parse_bc(bc.clone(), ctl, "META")?;
             let current_ref = false;
             let spinlock: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
             path = get_path_or_internal_id(&path, ctl, "META", &spinlock)?;
@@ -854,7 +854,7 @@ pub fn proc_meta_core(lines: &Vec<String>, mut ctl: &mut EncloneControl) -> Resu
                 path = format!("{}/multi/vdj_t", path);
             }
             if !gpath.is_empty() {
-                gpath = get_path_or_internal_id(&gpath, &mut ctl, "META", &spinlock)?;
+                gpath = get_path_or_internal_id(&gpath, ctl, "META", &spinlock)?;
                 if path_exists(&format!("{}/count", gpath)) {
                     gpath = format!("{}/count", gpath);
                 }
@@ -887,7 +887,7 @@ pub fn proc_meta_core(lines: &Vec<String>, mut ctl: &mut EncloneControl) -> Resu
     Ok(())
 }
 
-pub fn proc_meta(f: &str, mut ctl: &mut EncloneControl) -> Result<(), String> {
+pub fn proc_meta(f: &str, ctl: &mut EncloneControl) -> Result<(), String> {
     if !path_exists(f) {
         return Err("\nCan't find the file referenced by your META argument.\n".to_string());
     }
@@ -906,5 +906,5 @@ pub fn proc_meta(f: &str, mut ctl: &mut EncloneControl) -> Result<(), String> {
         let s = line.unwrap();
         lines.push(s);
     }
-    proc_meta_core(&lines, &mut ctl)
+    proc_meta_core(&lines, ctl)
 }

--- a/enclone_args/src/proc_args_check.rs
+++ b/enclone_args/src/proc_args_check.rs
@@ -184,7 +184,7 @@ fn check_gene_fb(
     }
     for x in to_check.iter() {
         let mut x = x.to_string();
-        if x.contains(":") {
+        if x.contains(':') {
             x = x.after(":").to_string();
         }
         if !gex_info.have_gex
@@ -555,7 +555,7 @@ pub fn check_pcols(
 pub fn check_cvars(ctl: &EncloneControl) -> Result<(), String> {
     for x in ctl.clono_print_opt.cvars.iter() {
         let mut x = x.to_string();
-        if x.contains(":") {
+        if x.contains(':') {
             x = x.after(":").to_string();
         }
         let mut ok = CVARS_ALLOWED.contains(&x.as_str());
@@ -606,7 +606,7 @@ pub fn check_one_lvar(
         }
     }
     let mut x = x.to_string();
-    if x.contains(":") {
+    if x.contains(':') {
         x = x.after(":").to_string();
     }
 
@@ -722,7 +722,7 @@ pub fn check_one_lvar(
         }
         let y = z.after(&class);
         let reg = Regex::new(y);
-        if reg.is_err() || y.contains("_") {
+        if reg.is_err() || y.contains('_') {
             return Err(format!(
                 "\nThe string after {} in your lead or parseable variable {} is not a valid \
                 regular expression for amino acids.\n",
@@ -746,7 +746,7 @@ pub fn check_one_lvar(
 
     // Check for patterns.
 
-    if is_pattern(&x.to_string(), false) {
+    if is_pattern(&x, false) {
         return Ok(true);
     }
 

--- a/enclone_args/src/proc_args_post.rs
+++ b/enclone_args/src/proc_args_post.rs
@@ -351,7 +351,7 @@ pub fn proc_args_post(
     if !metas.is_empty() {
         let f = &metas[metas.len() - 1];
         let f = get_path_fail(f, ctl, "META")?;
-        proc_meta(&f, &mut ctl)?;
+        proc_meta(&f, ctl)?;
     }
     if !metaxs.is_empty() {
         let lines0 = metaxs[metaxs.len() - 1].split(';').collect::<Vec<&str>>();
@@ -359,12 +359,12 @@ pub fn proc_args_post(
         for i in 0..lines0.len() {
             lines.push(lines0[i].to_string());
         }
-        proc_meta_core(&lines, &mut ctl)?;
+        proc_meta_core(&lines, ctl)?;
     }
     ctl.perf_stats(&t, "in proc_meta");
     if !xcrs.is_empty() {
         let arg = &xcrs[xcrs.len() - 1];
-        proc_xcr(arg, gex, bc, have_gex, &mut ctl)?;
+        proc_xcr(arg, gex, bc, have_gex, ctl)?;
     }
 
     // More argument sanity checking.
@@ -499,7 +499,7 @@ pub fn proc_args_post(
         }
     }
     ctl.perf_stats(&t, "after main args loop 2");
-    proc_args_tail(&mut ctl, args)?;
+    proc_args_tail(ctl, args)?;
 
     // Sort chains_to_align.
 

--- a/enclone_args/src/read_json.rs
+++ b/enclone_args/src/read_json.rs
@@ -650,8 +650,8 @@ pub fn read_json(
     reannotate: bool,
     cr_version: &mut String,
     ctl: &EncloneControl,
-    mut vdj_cells: &mut Vec<String>,
-    mut gex_cells: &mut Vec<String>,
+    vdj_cells: &mut Vec<String>,
+    gex_cells: &mut Vec<String>,
     gex_cells_specified: &mut bool,
 ) -> Result<Vec<Vec<TigData>>, String> {
     *gex_cells_specified = false;
@@ -752,7 +752,7 @@ pub fn read_json(
         }
         tigs.append(&mut results[i].5);
     }
-    unique_sort(&mut gex_cells);
+    unique_sort(gex_cells);
     let mut tig_bc = Vec::<Vec<TigData>>::new();
     let mut r = 0;
     while r < tigs.len() {
@@ -776,7 +776,7 @@ pub fn read_json(
         }
         r = s;
     }
-    unique_sort(&mut vdj_cells);
+    unique_sort(vdj_cells);
     Ok(tig_bc)
 }
 

--- a/enclone_core/src/packing.rs
+++ b/enclone_core/src/packing.rs
@@ -12,12 +12,12 @@ use zstd::block::{Compressor, Decompressor};
 // that it's a good tradeoff.
 
 pub fn compress_bytes(x: &Vec<u8>) -> Vec<u8> {
-    Compressor::new().compress(&x, 0).unwrap()
+    Compressor::new().compress(x, 0).unwrap()
 }
 
 pub fn uncompress_bytes(x: &[u8], uncompressed_size: usize) -> Vec<u8> {
     Decompressor::new()
-        .decompress(&x, uncompressed_size)
+        .decompress(x, uncompressed_size)
         .unwrap()
 }
 
@@ -107,7 +107,7 @@ pub fn restore_vec_string(x: &Vec<u8>, pos: &mut usize) -> Result<Vec<String>, (
 
 pub fn save_vec_string_comp(x: &Vec<String>) -> Vec<u8> {
     let mut bytes = Vec::<u8>::new();
-    let z = save_vec_string(&x);
+    let z = save_vec_string(x);
     let mut y = compress_bytes(&z);
     bytes.append(&mut u32_bytes(y.len()));
     bytes.append(&mut u32_bytes(z.len()));
@@ -151,7 +151,7 @@ pub fn restore_vec_vec_string(x: &Vec<u8>, pos: &mut usize) -> Result<Vec<Vec<St
     *pos += 4;
     let mut y = vec![Vec::<String>::new(); n];
     for j in 0..n {
-        y[j] = restore_vec_string(&x, pos)?;
+        y[j] = restore_vec_string(x, pos)?;
     }
     Ok(y)
 }
@@ -250,7 +250,7 @@ pub fn restore_vec_bool(x: &Vec<u8>, pos: &mut usize) -> Result<Vec<bool>, ()> {
     }
     let mut y = vec![false; n];
     for j in 0..n {
-        y[j] = if x[*pos] == 1 { true } else { false };
+        y[j] = x[*pos] == 1;
         *pos += 1;
     }
     Ok(y)

--- a/enclone_core/src/print_tools.rs
+++ b/enclone_core/src/print_tools.rs
@@ -60,7 +60,7 @@ pub fn emit_codon_color_escape(c: &[u8], log: &mut Vec<u8>) {
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 
-pub fn color_by_property(c: &[u8], mut log: &mut Vec<u8>) {
+pub fn color_by_property(c: &[u8], log: &mut Vec<u8>) {
     for i in 0..c.len() {
         let mut color = 7;
         if c[i] == b'A'
@@ -89,7 +89,7 @@ pub fn color_by_property(c: &[u8], mut log: &mut Vec<u8>) {
         }
         fwrite!(log, "{}", c[i] as char);
         if color < 7 {
-            emit_end_escape(&mut log);
+            emit_end_escape(log);
         }
     }
 }

--- a/enclone_core/src/stringulate.rs
+++ b/enclone_core/src/stringulate.rs
@@ -22,7 +22,7 @@ use string_utils::*;
 const DOUBLE: &str = "";
 
 pub fn flatten_vec_string(v: &[String]) -> String {
-    format!("{}{}{}", DOUBLE, v.iter().format(&DOUBLE), DOUBLE)
+    format!("{}{}{}", DOUBLE, v.iter().format(DOUBLE), DOUBLE)
 }
 
 pub fn unflatten_string(s: &str) -> Vec<String> {
@@ -47,7 +47,7 @@ pub fn unpack_to_het_string(s: &str) -> Vec<HetString> {
     let fields: Vec<String> = s.split(&DOUBLE).map(str::to_owned).collect();
     let mut i = 0;
     while i < fields.len() {
-        if fields[i].len() > 0 {
+        if !fields[i].is_empty() {
             v.push(HetString {
                 name: "String".to_string(),
                 content: fields[i].to_string(),
@@ -84,7 +84,7 @@ impl DescriptionTable {
         flatten_vec_string(&v)
     }
     pub fn from_string(x: &str) -> Self {
-        let v = unflatten_string(&x);
+        let v = unflatten_string(x);
         DescriptionTable {
             display_text: v[2].clone(),
             spreadsheet_text: v[3].clone(),
@@ -117,7 +117,7 @@ impl FeatureBarcodeAlluvialTableSet {
         flatten_vec_string(&v)
     }
     pub fn from_string(x: &str) -> Self {
-        let v = unflatten_string(&x);
+        let v = unflatten_string(x);
         let n = v[1].force_usize() / 3;
         let mut s = Vec::new();
         for i in 0..n {
@@ -127,7 +127,7 @@ impl FeatureBarcodeAlluvialTableSet {
                 spreadsheet_text: v[2 + 3 * i + 2].clone(),
             });
         }
-        FeatureBarcodeAlluvialTableSet { s: s }
+        FeatureBarcodeAlluvialTableSet { s }
     }
 }
 
@@ -156,7 +156,7 @@ impl FeatureBarcodeAlluvialReadsTableSet {
         flatten_vec_string(&v)
     }
     pub fn from_string(x: &str) -> Self {
-        let v = unflatten_string(&x);
+        let v = unflatten_string(x);
         let n = v[1].force_usize() / 3;
         let mut s = Vec::new();
         for i in 0..n {
@@ -166,6 +166,6 @@ impl FeatureBarcodeAlluvialReadsTableSet {
                 spreadsheet_text: v[2 + 3 * i + 2].clone(),
             });
         }
-        FeatureBarcodeAlluvialReadsTableSet { s: s }
+        FeatureBarcodeAlluvialReadsTableSet { s }
     }
 }

--- a/enclone_print/src/loupe.rs
+++ b/enclone_print/src/loupe.rs
@@ -76,10 +76,7 @@ pub fn make_donor_refs(
 }
 
 fn amino_acid(seq: &[u8], start: usize) -> Vec<u8> {
-    seq[start..]
-        .chunks_exact(3)
-        .map(|codon| codon_to_aa(codon))
-        .collect()
+    seq[start..].chunks_exact(3).map(codon_to_aa).collect()
 }
 
 pub fn make_loupe_clonotype(

--- a/enclone_print/src/print_utils1.rs
+++ b/enclone_print/src/print_utils1.rs
@@ -564,7 +564,7 @@ pub fn start_gen(
         }
         fwrite!(&mut mlog, "██");
         if ctl.pretty {
-            emit_end_escape(&mut mlog);
+            emit_end_escape(mlog);
         }
         fwriteln!(
             &mut mlog,

--- a/enclone_print/src/print_utils2.rs
+++ b/enclone_print/src/print_utils2.rs
@@ -680,45 +680,45 @@ pub fn row_fill(
                 varmat,
                 out_data,
                 stats,
-            )? {
-                if *var == "amino" && col_var {
-                    let mut last_color = "black".to_string();
-                    for k in 0..show_aa[col].len() {
-                        let p = show_aa[col][k];
-                        if k > 0
-                            && field_types[col][k] != field_types[col][k - 1]
-                            && !ctl.gen_opt.nospaces
-                        {
-                            cx[col][jj] += " ";
-                        }
-                        if 3 * p + 3 <= seq_amino.len()
-                            && seq_amino[3 * p..3 * p + 3].to_vec() == b"---".to_vec()
-                        {
-                            cx[col][jj] += "-";
-                        } else if 3 * p + 3 > seq_amino.len()
-                            || seq_amino[3 * p..3 * p + 3].contains(&b'-')
-                        {
-                            cx[col][jj] += "*";
-                        } else {
-                            let x = &peer_groups[rsi.vids[col]];
-                            let last = k == show_aa[col].len() - 1;
-                            let log = color_codon(
-                                ctl,
-                                &seq_amino,
-                                ref_diff_pos,
-                                x,
-                                col,
-                                mid,
-                                p,
-                                u,
-                                &mut last_color,
-                                last,
-                                cdr3_con,
-                                exacts,
-                                exact_clonotypes,
-                            );
-                            cx[col][jj] += strme(&log);
-                        }
+            )? && *var == "amino"
+                && col_var
+            {
+                let mut last_color = "black".to_string();
+                for k in 0..show_aa[col].len() {
+                    let p = show_aa[col][k];
+                    if k > 0
+                        && field_types[col][k] != field_types[col][k - 1]
+                        && !ctl.gen_opt.nospaces
+                    {
+                        cx[col][jj] += " ";
+                    }
+                    if 3 * p + 3 <= seq_amino.len()
+                        && seq_amino[3 * p..3 * p + 3].to_vec() == b"---".to_vec()
+                    {
+                        cx[col][jj] += "-";
+                    } else if 3 * p + 3 > seq_amino.len()
+                        || seq_amino[3 * p..3 * p + 3].contains(&b'-')
+                    {
+                        cx[col][jj] += "*";
+                    } else {
+                        let x = &peer_groups[rsi.vids[col]];
+                        let last = k == show_aa[col].len() - 1;
+                        let log = color_codon(
+                            ctl,
+                            &seq_amino,
+                            ref_diff_pos,
+                            x,
+                            col,
+                            mid,
+                            p,
+                            u,
+                            &mut last_color,
+                            last,
+                            cdr3_con,
+                            exacts,
+                            exact_clonotypes,
+                        );
+                        cx[col][jj] += strme(&log);
                     }
                 }
             }

--- a/enclone_print/src/print_utils5.rs
+++ b/enclone_print/src/print_utils5.rs
@@ -492,7 +492,7 @@ pub fn build_diff_row(
                     row.push(xdots);
                 } else {
                     let mut v = rsi.cvars[col][m].clone();
-                    if v.contains(":") {
+                    if v.contains(':') {
                         v = v.before(":").to_string();
                     }
                     row.push(v);

--- a/enclone_print/src/proc_cvar_auto.rs
+++ b/enclone_print/src/proc_cvar_auto.rs
@@ -39,12 +39,12 @@ pub fn proc_cvar_auto(
     stats: &mut Vec<(String, Vec<String>)>,
 ) -> Result<bool, String> {
     let mut vname = var.clone();
-    if var.contains(":") {
+    if var.contains(':') {
         vname = var.after(":").to_string();
     }
     let cvars = &ctl.clono_print_opt.cvars;
     let mut abbrc = format!("{}{}", var, col + 1);
-    if var.contains(":") {
+    if var.contains(':') {
         abbrc = var.before(":").to_string();
     }
     let val = if false {
@@ -157,16 +157,14 @@ pub fn proc_cvar_auto(
                     .to_vec();
                 y = stringme(&aa_seq(&dna, 0));
             }
-        } else {
-            if x.cdr2_start.is_some()
-                && x.fr3_start.is_some()
-                && x.cdr2_start.unwrap() <= x.fr3_start.unwrap()
-            {
-                let dna = refdata.refs[x.v_ref_id].to_ascii_vec()
-                    [x.cdr2_start.unwrap()..x.fr3_start.unwrap()]
-                    .to_vec();
-                y = stringme(&aa_seq(&dna, 0));
-            }
+        } else if x.cdr2_start.is_some()
+            && x.fr3_start.is_some()
+            && x.cdr2_start.unwrap() <= x.fr3_start.unwrap()
+        {
+            let dna = refdata.refs[x.v_ref_id].to_ascii_vec()
+                [x.cdr2_start.unwrap()..x.fr3_start.unwrap()]
+                .to_vec();
+            y = stringme(&aa_seq(&dna, 0));
         }
 
         (y, Vec::new(), "clono".to_string())
@@ -189,16 +187,14 @@ pub fn proc_cvar_auto(
                     .to_vec();
                 y = stringme(&dna);
             }
-        } else {
-            if x.cdr2_start.is_some()
-                && x.fr3_start.is_some()
-                && x.cdr2_start.unwrap() <= x.fr3_start.unwrap()
-            {
-                let dna = refdata.refs[x.v_ref_id].to_ascii_vec()
-                    [x.cdr2_start.unwrap()..x.fr3_start.unwrap()]
-                    .to_vec();
-                y = stringme(&dna);
-            }
+        } else if x.cdr2_start.is_some()
+            && x.fr3_start.is_some()
+            && x.cdr2_start.unwrap() <= x.fr3_start.unwrap()
+        {
+            let dna = refdata.refs[x.v_ref_id].to_ascii_vec()
+                [x.cdr2_start.unwrap()..x.fr3_start.unwrap()]
+                .to_vec();
+            y = stringme(&dna);
         }
 
         (y, Vec::new(), "clono".to_string())
@@ -213,12 +209,12 @@ pub fn proc_cvar_auto(
         let mut y = "unknown".to_string();
         let c;
         if arg1 == 1 {
-            c = get_cdr1(&x, 0, 0);
+            c = get_cdr1(x, 0, 0);
             if c.is_some() {
                 y = stringme(&aa_seq(c.unwrap().as_bytes(), 0));
             }
         } else if arg1 == 2 {
-            c = get_cdr2(&x, 0, 0);
+            c = get_cdr2(x, 0, 0);
             if c.is_some() {
                 y = stringme(&aa_seq(c.unwrap().as_bytes(), 0));
             }
@@ -243,7 +239,7 @@ pub fn proc_cvar_auto(
                 left = 3;
                 right = 3;
             }
-            c = get_cdr1(&x, left, right);
+            c = get_cdr1(x, left, right);
             if c.is_some() {
                 y = stringme(&aa_seq(c.unwrap().as_bytes(), 0));
             }
@@ -256,12 +252,12 @@ pub fn proc_cvar_auto(
                 left = 1;
                 right = 0;
             }
-            c = get_cdr2(&x, left, right);
+            c = get_cdr2(x, left, right);
             if c.is_some() {
                 y = stringme(&aa_seq(c.unwrap().as_bytes(), 0));
             }
         } else {
-            c = get_cdr3(&x, -1, -1);
+            c = get_cdr3(x, -1, -1);
             if c.is_some() {
                 y = stringme(&aa_seq(c.unwrap().as_bytes(), 0));
             }
@@ -270,7 +266,7 @@ pub fn proc_cvar_auto(
         (y, Vec::new(), "exact".to_string())
     } else if vname.starts_with("cdr")
         && vname.after("cdr").contains("_aa_")
-        && vname.after("cdr").after("_aa_").contains("_")
+        && vname.after("cdr").after("_aa_").contains('_')
         && vname
             .after("cdr")
             .after("_aa_")
@@ -301,68 +297,12 @@ pub fn proc_cvar_auto(
             if x.cdr1_start.is_some()
                 && x.fr2_start.is_some()
                 && x.cdr1_start.unwrap() <= x.fr2_start.unwrap()
+                && x.cdr1_start.unwrap() as i64 - left >= 0
+                && x.cdr1_start.unwrap() as i64 - left < x.seq_del_amino.len() as i64
+                && x.fr2_start.unwrap() as i64 + right > 0
+                && x.fr2_start.unwrap() as i64 + right <= x.seq_del_amino.len() as i64
             {
-                if x.cdr1_start.unwrap() as i64 - left >= 0
-                    && x.cdr1_start.unwrap() as i64 - left < x.seq_del_amino.len() as i64
-                    && x.fr2_start.unwrap() as i64 + right > 0
-                    && x.fr2_start.unwrap() as i64 + right <= x.seq_del_amino.len() as i64
-                {
-                    for p in
-                        x.cdr1_start.unwrap() as i64 - left..x.fr2_start.unwrap() as i64 + right
-                    {
-                        let p = p as usize;
-                        for j in 0..x.ins.len() {
-                            if x.ins[j].0 == p {
-                                let mut z = x.ins[j].1.clone();
-                                dna.append(&mut z);
-                            }
-                        }
-                        if x.seq_del_amino[p] != b'-' {
-                            dna.push(x.seq_del_amino[p]);
-                        }
-                    }
-                    test_internal_error_seq(&x.seq, &dna, &x.cdr3_aa)?;
-                    y = stringme(&aa_seq(&dna, 0));
-                }
-            }
-        } else if arg1 == 2 {
-            if x.cdr2_start.is_some()
-                && x.fr3_start.is_some()
-                && x.cdr2_start.unwrap() <= x.fr3_start.unwrap()
-            {
-                if x.cdr2_start.unwrap() as i64 - left >= 0
-                    && x.cdr2_start.unwrap() as i64 - left < x.seq_del_amino.len() as i64
-                    && x.fr3_start.unwrap() as i64 + right > 0
-                    && x.fr3_start.unwrap() as i64 + right <= x.seq_del_amino.len() as i64
-                {
-                    for p in
-                        x.cdr2_start.unwrap() as i64 - left..x.fr3_start.unwrap() as i64 + right
-                    {
-                        let p = p as usize;
-                        for j in 0..x.ins.len() {
-                            if x.ins[j].0 == p {
-                                let mut z = x.ins[j].1.clone();
-                                dna.append(&mut z);
-                            }
-                        }
-                        if x.seq_del_amino[p] != b'-' {
-                            dna.push(x.seq_del_amino[p]);
-                        }
-                    }
-                    test_internal_error_seq(&x.seq, &dna, &x.cdr3_aa)?;
-                    y = stringme(&aa_seq(&dna, 0));
-                }
-            }
-        } else {
-            if x.cdr3_start as i64 - left >= 0
-                && x.cdr3_start as i64 - left < x.seq_del_amino.len() as i64
-                && x.cdr3_start as i64 + 3 * x.cdr3_aa.len() as i64 + right > 0
-                && x.cdr3_start as i64 + 3 * x.cdr3_aa.len() as i64 + right
-                    <= x.seq_del_amino.len() as i64
-            {
-                for p in x.cdr3_start as i64 - left
-                    ..x.cdr3_start as i64 + 3 * x.cdr3_aa.len() as i64 + right
-                {
+                for p in x.cdr1_start.unwrap() as i64 - left..x.fr2_start.unwrap() as i64 + right {
                     let p = p as usize;
                     for j in 0..x.ins.len() {
                         if x.ins[j].0 == p {
@@ -377,6 +317,52 @@ pub fn proc_cvar_auto(
                 test_internal_error_seq(&x.seq, &dna, &x.cdr3_aa)?;
                 y = stringme(&aa_seq(&dna, 0));
             }
+        } else if arg1 == 2 {
+            if x.cdr2_start.is_some()
+                && x.fr3_start.is_some()
+                && x.cdr2_start.unwrap() <= x.fr3_start.unwrap()
+                && x.cdr2_start.unwrap() as i64 - left >= 0
+                && x.cdr2_start.unwrap() as i64 - left < x.seq_del_amino.len() as i64
+                && x.fr3_start.unwrap() as i64 + right > 0
+                && x.fr3_start.unwrap() as i64 + right <= x.seq_del_amino.len() as i64
+            {
+                for p in x.cdr2_start.unwrap() as i64 - left..x.fr3_start.unwrap() as i64 + right {
+                    let p = p as usize;
+                    for j in 0..x.ins.len() {
+                        if x.ins[j].0 == p {
+                            let mut z = x.ins[j].1.clone();
+                            dna.append(&mut z);
+                        }
+                    }
+                    if x.seq_del_amino[p] != b'-' {
+                        dna.push(x.seq_del_amino[p]);
+                    }
+                }
+                test_internal_error_seq(&x.seq, &dna, &x.cdr3_aa)?;
+                y = stringme(&aa_seq(&dna, 0));
+            }
+        } else if x.cdr3_start as i64 - left >= 0
+            && x.cdr3_start as i64 - left < x.seq_del_amino.len() as i64
+            && x.cdr3_start as i64 + 3 * x.cdr3_aa.len() as i64 + right > 0
+            && x.cdr3_start as i64 + 3 * x.cdr3_aa.len() as i64 + right
+                <= x.seq_del_amino.len() as i64
+        {
+            for p in
+                x.cdr3_start as i64 - left..x.cdr3_start as i64 + 3 * x.cdr3_aa.len() as i64 + right
+            {
+                let p = p as usize;
+                for j in 0..x.ins.len() {
+                    if x.ins[j].0 == p {
+                        let mut z = x.ins[j].1.clone();
+                        dna.append(&mut z);
+                    }
+                }
+                if x.seq_del_amino[p] != b'-' {
+                    dna.push(x.seq_del_amino[p]);
+                }
+            }
+            test_internal_error_seq(&x.seq, &dna, &x.cdr3_aa)?;
+            y = stringme(&aa_seq(&dna, 0));
         }
 
         (y, Vec::new(), "exact".to_string())
@@ -391,9 +377,9 @@ pub fn proc_cvar_auto(
         let mut y = "unknown".to_string();
         let c;
         if arg1 == 1 {
-            c = get_cdr1(&x, 0, 0);
+            c = get_cdr1(x, 0, 0);
         } else if arg1 == 2 {
-            c = get_cdr2(&x, 0, 0);
+            c = get_cdr2(x, 0, 0);
         } else {
             c = Some(x.cdr3_dna.clone());
         }
@@ -413,9 +399,9 @@ pub fn proc_cvar_auto(
         let mut y = "unknown".to_string();
         let c;
         if arg1 == 1 {
-            c = get_cdr1(&x, 0, 0);
+            c = get_cdr1(x, 0, 0);
         } else if arg1 == 2 {
-            c = get_cdr2(&x, 0, 0);
+            c = get_cdr2(x, 0, 0);
         } else {
             c = Some(x.cdr3_dna.clone());
         }
@@ -458,7 +444,7 @@ pub fn proc_cvar_auto(
             "exact".to_string(),
         )
     } else if vname == "comp" {
-        let (comp, _edit) = comp_edit(&ex, mid, col, &refdata, &dref, &rsi);
+        let (comp, _edit) = comp_edit(ex, mid, col, refdata, dref, rsi);
 
         (format!("{}", comp), Vec::new(), "exact".to_string())
     } else if vname == "const" {
@@ -705,7 +691,7 @@ pub fn proc_cvar_auto(
             "exact".to_string(),
         )
     } else if vname == "edit" {
-        let (_comp, edit) = comp_edit(&ex, mid, col, &refdata, &dref, &rsi);
+        let (_comp, edit) = comp_edit(ex, mid, col, refdata, dref, rsi);
 
         (edit, Vec::new(), "exact".to_string())
     } else if vname.starts_with("fwr")
@@ -719,17 +705,17 @@ pub fn proc_cvar_auto(
         let mut y = "unknown".to_string();
         let c;
         if arg1 == 1 {
-            c = get_fwr1(&x);
+            c = get_fwr1(x);
         } else if arg1 == 2 {
-            c = get_fwr2(&x);
+            c = get_fwr2(x);
         } else if arg1 == 3 {
-            c = get_fwr3(&x);
+            c = get_fwr3(x);
         } else {
             let x = &ex.share[mid];
             let start = rsi.cdr3_starts[col] + 3 * rsi.cdr3_lens[col];
             let stop = rsi.seq_del_lens[col];
             let dna = &x.seq_del_amino[start..stop];
-            c = Some(stringme(&dna));
+            c = Some(stringme(dna));
         }
         if c.is_some() {
             y = stringme(&aa_seq(c.unwrap().as_bytes(), 0));
@@ -792,17 +778,17 @@ pub fn proc_cvar_auto(
         let mut y = "unknown".to_string();
         let c;
         if arg1 == 1 {
-            c = get_fwr1(&x);
+            c = get_fwr1(x);
         } else if arg1 == 2 {
-            c = get_fwr2(&x);
+            c = get_fwr2(x);
         } else if arg1 == 3 {
-            c = get_fwr3(&x);
+            c = get_fwr3(x);
         } else {
             let x = &ex.share[mid];
             let start = rsi.cdr3_starts[col] + 3 * rsi.cdr3_lens[col];
             let stop = rsi.seq_del_lens[col];
             let dna = &x.seq_del_amino[start..stop];
-            c = Some(stringme(&dna));
+            c = Some(stringme(dna));
         }
         if c.is_some() {
             y = c.unwrap();
@@ -865,17 +851,17 @@ pub fn proc_cvar_auto(
         let mut y = "unknown".to_string();
         let c;
         if arg1 == 1 {
-            c = get_fwr1(&x);
+            c = get_fwr1(x);
         } else if arg1 == 2 {
-            c = get_fwr2(&x);
+            c = get_fwr2(x);
         } else if arg1 == 3 {
-            c = get_fwr3(&x);
+            c = get_fwr3(x);
         } else {
             let x = &ex.share[mid];
             let start = rsi.cdr3_starts[col] + 3 * rsi.cdr3_lens[col];
             let stop = rsi.seq_del_lens[col];
             let dna = &x.seq_del_amino[start..stop];
-            c = Some(stringme(&dna));
+            c = Some(stringme(dna));
         }
         if c.is_some() {
             y = format!("{}", c.unwrap().len() / 3);
@@ -1027,8 +1013,8 @@ pub fn proc_cvar_auto(
         }
 
         (String::new(), vals, "cell".to_string())
-    } else if vname.starts_with("q")
-        && vname.ends_with("_")
+    } else if vname.starts_with('q')
+        && vname.ends_with('_')
         && vname.between2("q", "_").parse::<i64>().is_ok()
         && vname.between2("q", "_").force_i64() >= 0
     {
@@ -1156,7 +1142,7 @@ pub fn proc_cvar_auto(
         for j in 0..ex.clones.len() {
             numis.push(ex.clones[j][mid].umi_count);
         }
-        numis.sort();
+        numis.sort_unstable();
 
         (
             format!("{}", numis.iter().max().unwrap()),
@@ -1168,7 +1154,7 @@ pub fn proc_cvar_auto(
         for j in 0..ex.clones.len() {
             numis.push(ex.clones[j][mid].umi_count);
         }
-        numis.sort();
+        numis.sort_unstable();
         let utot: usize = numis.iter().sum();
         let u_mean = (utot as f64 / numis.len() as f64).round() as usize;
 
@@ -1178,7 +1164,7 @@ pub fn proc_cvar_auto(
         for j in 0..ex.clones.len() {
             numis.push(ex.clones[j][mid].umi_count);
         }
-        numis.sort();
+        numis.sort_unstable();
 
         (
             format!("{}", numis.iter().min().unwrap()),
@@ -1206,7 +1192,7 @@ pub fn proc_cvar_auto(
         for j in 0..ex.clones.len() {
             numis.push(ex.clones[j][mid].umi_count);
         }
-        numis.sort();
+        numis.sort_unstable();
         let utot: usize = numis.iter().sum();
         let u_mean = (utot as f64 / numis.len() as f64).round() as usize;
 
@@ -1379,19 +1365,19 @@ pub fn proc_cvar_auto(
         )
     };
     if val.0 == "$UNDEFINED" {
-        return Ok(false);
+        Ok(false)
     } else {
         let (exact, cell, _level) = &val;
         let mut varc = format!("{}{}", var, col + 1);
-        if exact.len() > 0 {
-            if j < rsi.cvars[col].len() && cvars.contains(&var) {
+        if !exact.is_empty() {
+            if j < rsi.cvars[col].len() && cvars.contains(var) {
                 cx[col][j] = exact.clone();
             }
             if pass == 2
-                && ((ctl.parseable_opt.pout.len() > 0
+                && ((!ctl.parseable_opt.pout.is_empty()
                     && (ctl.parseable_opt.pchains == "max"
                         || col < ctl.parseable_opt.pchains.force_usize()))
-                    || extra_args.len() > 0)
+                    || !extra_args.is_empty())
             {
                 abbrc = abbrc.replace("_Σ", "_sum");
                 abbrc = abbrc.replace("_μ", "_mean");
@@ -1403,7 +1389,7 @@ pub fn proc_cvar_auto(
 
                 let mut val_clean = String::new();
                 let mut chars = Vec::<char>::new();
-                let valx = format!("{}", exact);
+                let valx = exact.to_string();
                 for c in valx.chars() {
                     chars.push(c);
                 }
@@ -1425,8 +1411,8 @@ pub fn proc_cvar_auto(
 
                 // let varc = format!("{}{}", v, col + 1);
                 if pcols_sort.is_empty()
-                    || bin_member(&pcols_sort, &varc)
-                    || bin_member(&extra_args, &varc)
+                    || bin_member(pcols_sort, &varc)
+                    || bin_member(extra_args, &varc)
                 {
                     out_data[u].insert(abbrc.clone(), val_clean);
                 }
@@ -1436,18 +1422,16 @@ pub fn proc_cvar_auto(
             } else {
                 stats.push((abbrc, cell.to_vec()));
             }
-        } else if cell.len() > 0 {
-            if pass == 2
-                && ((ctl.parseable_opt.pchains == "max"
-                    || col < ctl.parseable_opt.pchains.force_usize())
-                    || !extra_args.is_empty())
-            {
-                if pcols_sort.is_empty() || bin_member(pcols_sort, &varc) {
-                    let vals = format!("{}", cell.iter().format(&POUT_SEP));
-                    out_data[u].insert(abbrc, vals);
-                }
-            }
+        } else if !cell.is_empty()
+            && pass == 2
+            && ((ctl.parseable_opt.pchains == "max"
+                || col < ctl.parseable_opt.pchains.force_usize())
+                || !extra_args.is_empty())
+            && (pcols_sort.is_empty() || bin_member(pcols_sort, &varc))
+        {
+            let vals = format!("{}", cell.iter().format(POUT_SEP));
+            out_data[u].insert(abbrc, vals);
         }
-        return Ok(true);
+        Ok(true)
     }
 }

--- a/enclone_print/src/proc_lvar_auto.rs
+++ b/enclone_print/src/proc_lvar_auto.rs
@@ -54,7 +54,7 @@ pub fn proc_lvar_auto(
     let verbose = ctl.gen_opt.row_fill_verbose;
     let mut vname = var.clone();
     let mut abbr = var.clone();
-    if var.contains(":") {
+    if var.contains(':') {
         abbr = var.before(":").to_string();
         vname = var.after(":").to_string();
     }
@@ -96,23 +96,24 @@ pub fn proc_lvar_auto(
     } else if bin_member(&ctl.gen_opt.info_fields, var) {
         let mut val = String::new();
         for q in 0..ctl.gen_opt.info_fields.len() {
-            if *var == ctl.gen_opt.info_fields[q] {
-                if ex.share.len() == 2 && ex.share[0].left != ex.share[1].left {
-                    let mut tag = String::new();
-                    for j in 0..ex.share.len() {
-                        if ex.share[j].left {
-                            tag += strme(&ex.share[j].seq);
-                        }
+            if *var == ctl.gen_opt.info_fields[q]
+                && ex.share.len() == 2
+                && ex.share[0].left != ex.share[1].left
+            {
+                let mut tag = String::new();
+                for j in 0..ex.share.len() {
+                    if ex.share[j].left {
+                        tag += strme(&ex.share[j].seq);
                     }
-                    tag += "_";
-                    for j in 0..ex.share.len() {
-                        if !ex.share[j].left {
-                            tag += strme(&ex.share[j].seq);
-                        }
+                }
+                tag += "_";
+                for j in 0..ex.share.len() {
+                    if !ex.share[j].left {
+                        tag += strme(&ex.share[j].seq);
                     }
-                    if ctl.gen_opt.info_data.contains_key(&tag) {
-                        val = ctl.gen_opt.info_data[&tag][q].clone();
-                    }
+                }
+                if ctl.gen_opt.info_data.contains_key(&tag) {
+                    val = ctl.gen_opt.info_data[&tag][q].clone();
                 }
             }
         }
@@ -144,11 +145,11 @@ pub fn proc_lvar_auto(
 
         (abbrev_list(&clust), clustf, "cell-exect".to_string())
     } else if vname.starts_with(&"count_")
-        && vname.after(&"count_").ends_with(&"")
-        && !vname.between2(&"count_", &"").contains("_")
-        && Regex::new(&vname.between2(&"count_", &"")).is_ok()
+        && vname.after("count_").ends_with(&"")
+        && !vname.between2("count_", "").contains('_')
+        && Regex::new(vname.between2("count_", "")).is_ok()
     {
-        let reg = Regex::new(&vname.between2(&"count_", &"")).unwrap();
+        let reg = Regex::new(vname.between2("count_", "")).unwrap();
         let mut n = 0;
         for j in 0..ex.share.len() {
             let aa = aa_seq(&ex.share[j].seq, 0); // seems inefficient
@@ -161,11 +162,11 @@ pub fn proc_lvar_auto(
             "cell-exact".to_string(),
         )
     } else if vname.starts_with(&"count_")
-        && vname.after(&"count_").ends_with(&"_cell")
-        && !vname.between2(&"count_", &"_cell").contains("_")
-        && Regex::new(&vname.between2(&"count_", &"_cell")).is_ok()
+        && vname.after("count_").ends_with(&"_cell")
+        && !vname.between2("count_", "_cell").contains('_')
+        && Regex::new(vname.between2("count_", "_cell")).is_ok()
     {
-        let reg = Regex::new(&vname.between2(&"count_", &"_cell")).unwrap();
+        let reg = Regex::new(vname.between2("count_", "_cell")).unwrap();
         let mut n = 0;
         for j in 0..ex.share.len() {
             let aa = aa_seq(&ex.share[j].seq, 0); // seems inefficient
@@ -179,11 +180,11 @@ pub fn proc_lvar_auto(
             "cell-exact".to_string(),
         )
     } else if vname.starts_with(&"count_cdr_")
-        && vname.after(&"count_cdr_").ends_with(&"")
-        && !vname.between2(&"count_cdr_", &"").contains("_")
-        && Regex::new(&vname.between2(&"count_cdr_", &"")).is_ok()
+        && vname.after("count_cdr_").ends_with(&"")
+        && !vname.between2("count_cdr_", "").contains('_')
+        && Regex::new(vname.between2("count_cdr_", "")).is_ok()
     {
-        let reg = Regex::new(&vname.between2(&"count_cdr_", &"")).unwrap();
+        let reg = Regex::new(vname.between2("count_cdr_", "")).unwrap();
         let mut n = 0;
         for j in 0..ex.share.len() {
             if ex.share[j].cdr1_start.is_some() && ex.share[j].fr2_start.is_some() {
@@ -214,11 +215,11 @@ pub fn proc_lvar_auto(
             "cell-exact".to_string(),
         )
     } else if vname.starts_with(&"count_cdr_")
-        && vname.after(&"count_cdr_").ends_with(&"_cell")
-        && !vname.between2(&"count_cdr_", &"_cell").contains("_")
-        && Regex::new(&vname.between2(&"count_cdr_", &"_cell")).is_ok()
+        && vname.after("count_cdr_").ends_with(&"_cell")
+        && !vname.between2("count_cdr_", "_cell").contains('_')
+        && Regex::new(vname.between2("count_cdr_", "_cell")).is_ok()
     {
-        let reg = Regex::new(&vname.between2(&"count_cdr_", &"_cell")).unwrap();
+        let reg = Regex::new(vname.between2("count_cdr_", "_cell")).unwrap();
         let mut n = 0;
         for j in 0..ex.share.len() {
             if ex.share[j].cdr1_start.is_some() && ex.share[j].fr2_start.is_some() {
@@ -251,15 +252,15 @@ pub fn proc_lvar_auto(
         )
     } else if vname.starts_with("count_cdr")
         && vname.ends_with("")
-        && vname.between2("count_cdr", "").contains("_")
+        && vname.between2("count_cdr", "").contains('_')
         && vname.between("count_cdr", "_").parse::<i64>().is_ok()
         && vname.between("count_cdr", "_").force_i64() >= 1
         && vname.between("count_cdr", "_").force_i64() <= 3
-        && !vname.after("count_cdr").between2(&"_", &"").contains("_")
-        && Regex::new(&vname.between2(&"_", &"")).is_ok()
+        && !vname.after("count_cdr").between2("_", "").contains('_')
+        && Regex::new(vname.between2("_", "")).is_ok()
     {
         let arg1 = vname.between("count_cdr", "_").force_i64();
-        let reg = Regex::new(&vname.after("count_cdr").between2(&"_", &"")).unwrap();
+        let reg = Regex::new(vname.after("count_cdr").between2("_", "")).unwrap();
         let mut n = 0;
         if arg1 == 1 {
             for j in 0..ex.share.len() {
@@ -299,18 +300,18 @@ pub fn proc_lvar_auto(
         )
     } else if vname.starts_with("count_cdr")
         && vname.ends_with("_cell")
-        && vname.between2("count_cdr", "_cell").contains("_")
+        && vname.between2("count_cdr", "_cell").contains('_')
         && vname.between("count_cdr", "_").parse::<i64>().is_ok()
         && vname.between("count_cdr", "_").force_i64() >= 1
         && vname.between("count_cdr", "_").force_i64() <= 3
         && !vname
             .after("count_cdr")
-            .between2(&"_", &"_cell")
-            .contains("_")
-        && Regex::new(&vname.between2(&"_", &"_cell")).is_ok()
+            .between2("_", "_cell")
+            .contains('_')
+        && Regex::new(vname.between2("_", "_cell")).is_ok()
     {
         let arg1 = vname.between("count_cdr", "_").force_i64();
-        let reg = Regex::new(&vname.after("count_cdr").between2(&"_", &"_cell")).unwrap();
+        let reg = Regex::new(vname.after("count_cdr").between2("_", "_cell")).unwrap();
         let mut n = 0;
         if arg1 == 1 {
             for j in 0..ex.share.len() {
@@ -350,11 +351,11 @@ pub fn proc_lvar_auto(
             "cell-exact".to_string(),
         )
     } else if vname.starts_with(&"count_fwr_")
-        && vname.after(&"count_fwr_").ends_with(&"")
-        && !vname.between2(&"count_fwr_", &"").contains("_")
-        && Regex::new(&vname.between2(&"count_fwr_", &"")).is_ok()
+        && vname.after("count_fwr_").ends_with(&"")
+        && !vname.between2("count_fwr_", "").contains('_')
+        && Regex::new(vname.between2("count_fwr_", "")).is_ok()
     {
-        let reg = Regex::new(&vname.between2(&"count_fwr_", &"")).unwrap();
+        let reg = Regex::new(vname.between2("count_fwr_", "")).unwrap();
         let mut n = 0;
         for j in 0..ex.share.len() {
             if ex.share[j].cdr1_start.is_some() {
@@ -392,11 +393,11 @@ pub fn proc_lvar_auto(
             "cell-exact".to_string(),
         )
     } else if vname.starts_with(&"count_fwr_")
-        && vname.after(&"count_fwr_").ends_with(&"_cell")
-        && !vname.between2(&"count_fwr_", &"_cell").contains("_")
-        && Regex::new(&vname.between2(&"count_fwr_", &"_cell")).is_ok()
+        && vname.after("count_fwr_").ends_with(&"_cell")
+        && !vname.between2("count_fwr_", "_cell").contains('_')
+        && Regex::new(vname.between2("count_fwr_", "_cell")).is_ok()
     {
-        let reg = Regex::new(&vname.between2(&"count_fwr_", &"_cell")).unwrap();
+        let reg = Regex::new(vname.between2("count_fwr_", "_cell")).unwrap();
         let mut n = 0;
         for j in 0..ex.share.len() {
             if ex.share[j].cdr1_start.is_some() {
@@ -436,15 +437,15 @@ pub fn proc_lvar_auto(
         )
     } else if vname.starts_with("count_fwr")
         && vname.ends_with("")
-        && vname.between2("count_fwr", "").contains("_")
+        && vname.between2("count_fwr", "").contains('_')
         && vname.between("count_fwr", "_").parse::<i64>().is_ok()
         && vname.between("count_fwr", "_").force_i64() >= 1
         && vname.between("count_fwr", "_").force_i64() <= 4
-        && !vname.after("count_fwr").between2(&"_", &"").contains("_")
-        && Regex::new(&vname.between2(&"_", &"")).is_ok()
+        && !vname.after("count_fwr").between2("_", "").contains('_')
+        && Regex::new(vname.between2("_", "")).is_ok()
     {
         let arg1 = vname.between("count_fwr", "_").force_i64();
-        let reg = Regex::new(&vname.after("count_fwr").between2(&"_", &"")).unwrap();
+        let reg = Regex::new(vname.after("count_fwr").between2("_", "")).unwrap();
         let mut n = 0;
         if arg1 == 1 {
             for j in 0..ex.share.len() {
@@ -494,18 +495,18 @@ pub fn proc_lvar_auto(
         )
     } else if vname.starts_with("count_fwr")
         && vname.ends_with("_cell")
-        && vname.between2("count_fwr", "_cell").contains("_")
+        && vname.between2("count_fwr", "_cell").contains('_')
         && vname.between("count_fwr", "_").parse::<i64>().is_ok()
         && vname.between("count_fwr", "_").force_i64() >= 1
         && vname.between("count_fwr", "_").force_i64() <= 4
         && !vname
             .after("count_fwr")
-            .between2(&"_", &"_cell")
-            .contains("_")
-        && Regex::new(&vname.between2(&"_", &"_cell")).is_ok()
+            .between2("_", "_cell")
+            .contains('_')
+        && Regex::new(vname.between2("_", "_cell")).is_ok()
     {
         let arg1 = vname.between("count_fwr", "_").force_i64();
-        let reg = Regex::new(&vname.after("count_fwr").between2(&"_", &"_cell")).unwrap();
+        let reg = Regex::new(vname.after("count_fwr").between2("_", "_cell")).unwrap();
         let mut n = 0;
         if arg1 == 1 {
             for j in 0..ex.share.len() {
@@ -1167,7 +1168,7 @@ pub fn proc_lvar_auto(
             Vec::new(),
             "exact".to_string(),
         )
-    } else if vname.starts_with("g")
+    } else if vname.starts_with('g')
         && vname.ends_with("")
         && vname.between2("g", "").parse::<i64>().is_ok()
         && vname.between2("g", "").force_i64() >= 0
@@ -1287,7 +1288,7 @@ pub fn proc_lvar_auto(
         let _exact = format!("{}", mults[u]);
         (String::new(), counts, "cell-exact".to_string())
     } else if vname.starts_with(&"n_")
-        && vname.after(&"n_").ends_with(&"")
+        && vname.after("n_").ends_with(&"")
         && (bin_member(
             &ctl.origin_info.dataset_list,
             &vname.between2("n_", "").to_string(),
@@ -1330,7 +1331,7 @@ pub fn proc_lvar_auto(
 
         (format!("{}", count), counts, "cell-exact".to_string())
     } else if vname.starts_with(&"n_")
-        && vname.after(&"n_").ends_with(&"_cell")
+        && vname.after("n_").ends_with(&"_cell")
         && (bin_member(
             &ctl.origin_info.dataset_list,
             &vname.between2("n_", "_cell").to_string(),
@@ -1474,7 +1475,7 @@ pub fn proc_lvar_auto(
         let mut nbc = Vec::<String>::new();
         for j in 0..ex.clones.len() {
             let bc = ex.clones[j][0].barcode.before("-").as_bytes();
-            let mut n = 0 as u64;
+            let mut n = 0_u64;
             for k in 0..bc.len() {
                 if k > 0 {
                     n *= 4;
@@ -1627,7 +1628,7 @@ pub fn proc_lvar_auto(
         )
     };
     if val.0 == "$UNDEFINED" {
-        return Ok(false);
+        Ok(false)
     } else {
         let (exact, cell, level) = &val;
         if level == "cell" && !var.ends_with("_cell") {
@@ -1639,13 +1640,13 @@ pub fn proc_lvar_auto(
                 row.push(String::new())
             }
             if pass == 2 {
-                speak!(u, abbr.to_string(), String::new());
+                speak!(u, abbr, String::new());
             }
             stats.push((abbr.to_string(), cell.clone()));
             if pass == 2 {
                 speak!(u, abbr, format!("{}", cell.iter().format(POUT_SEP)));
             }
-        } else if (exact.len() > 0 && !var.ends_with("_cell")) || cell.len() == 0 {
+        } else if (!exact.is_empty() && !var.ends_with("_cell")) || cell.is_empty() {
             if verbose {
                 eprint!("lvar {} ==> {}; ", var, exact);
                 eprintln!("i = {}, lvars.len() = {}", i, lvars.len());
@@ -1654,19 +1655,19 @@ pub fn proc_lvar_auto(
                 row.push(exact.clone())
             }
             if pass == 2 {
-                speak!(u, abbr.to_string(), exact.to_string());
+                speak!(u, abbr, exact.to_string());
             }
-            if cell.len() == 0 {
-                stats.push((abbr.to_string(), vec![exact.to_string(); ex.ncells()]));
+            if cell.is_empty() {
+                stats.push((abbr, vec![exact.to_string(); ex.ncells()]));
             } else {
-                stats.push((abbr.to_string(), cell.to_vec()));
+                stats.push((abbr, cell.to_vec()));
             }
-        } else if cell.len() > 0 {
+        } else if !cell.is_empty() {
             if pass == 2 {
                 speak!(u, abbr, format!("{}", cell.iter().format(POUT_SEP)));
             }
-            stats.push((abbr.to_string(), cell.to_vec()));
+            stats.push((abbr, cell.to_vec()));
         }
-        return Ok(true);
+        Ok(true)
     }
 }

--- a/enclone_print/src/proc_lvar_auto.rs
+++ b/enclone_print/src/proc_lvar_auto.rs
@@ -61,7 +61,7 @@ pub fn proc_lvar_auto(
 
     macro_rules! speak {
         ($u:expr, $var:expr, $val:expr) => {
-            if pass == 2 && (ctl.parseable_opt.pout.len() > 0 || extra_args.len() > 0) {
+            if pass == 2 && (!ctl.parseable_opt.pout.is_empty() || !extra_args.is_empty()) {
                 let mut v = $var.to_string();
                 v = v.replace("_Σ", "_sum");
                 v = v.replace("_μ", "_mean");
@@ -144,8 +144,8 @@ pub fn proc_lvar_auto(
         clust.sort_unstable();
 
         (abbrev_list(&clust), clustf, "cell-exect".to_string())
-    } else if vname.starts_with(&"count_")
-        && vname.after("count_").ends_with(&"")
+    } else if vname.starts_with("count_")
+        && vname.after("count_").ends_with("")
         && !vname.between2("count_", "").contains('_')
         && Regex::new(vname.between2("count_", "")).is_ok()
     {
@@ -161,8 +161,8 @@ pub fn proc_lvar_auto(
             vec![format!("{}", n); ex.ncells()],
             "cell-exact".to_string(),
         )
-    } else if vname.starts_with(&"count_")
-        && vname.after("count_").ends_with(&"_cell")
+    } else if vname.starts_with("count_")
+        && vname.after("count_").ends_with("_cell")
         && !vname.between2("count_", "_cell").contains('_')
         && Regex::new(vname.between2("count_", "_cell")).is_ok()
     {
@@ -179,8 +179,8 @@ pub fn proc_lvar_auto(
             vec![format!("{}", n); ex.ncells()],
             "cell-exact".to_string(),
         )
-    } else if vname.starts_with(&"count_cdr_")
-        && vname.after("count_cdr_").ends_with(&"")
+    } else if vname.starts_with("count_cdr_")
+        && vname.after("count_cdr_").ends_with("")
         && !vname.between2("count_cdr_", "").contains('_')
         && Regex::new(vname.between2("count_cdr_", "")).is_ok()
     {
@@ -214,8 +214,8 @@ pub fn proc_lvar_auto(
             vec![format!("{}", n); ex.ncells()],
             "cell-exact".to_string(),
         )
-    } else if vname.starts_with(&"count_cdr_")
-        && vname.after("count_cdr_").ends_with(&"_cell")
+    } else if vname.starts_with("count_cdr_")
+        && vname.after("count_cdr_").ends_with("_cell")
         && !vname.between2("count_cdr_", "_cell").contains('_')
         && Regex::new(vname.between2("count_cdr_", "_cell")).is_ok()
     {
@@ -350,8 +350,8 @@ pub fn proc_lvar_auto(
             vec![format!("{}", n); ex.ncells()],
             "cell-exact".to_string(),
         )
-    } else if vname.starts_with(&"count_fwr_")
-        && vname.after("count_fwr_").ends_with(&"")
+    } else if vname.starts_with("count_fwr_")
+        && vname.after("count_fwr_").ends_with("")
         && !vname.between2("count_fwr_", "").contains('_')
         && Regex::new(vname.between2("count_fwr_", "")).is_ok()
     {
@@ -392,8 +392,8 @@ pub fn proc_lvar_auto(
             vec![format!("{}", n); ex.ncells()],
             "cell-exact".to_string(),
         )
-    } else if vname.starts_with(&"count_fwr_")
-        && vname.after("count_fwr_").ends_with(&"_cell")
+    } else if vname.starts_with("count_fwr_")
+        && vname.after("count_fwr_").ends_with("_cell")
         && !vname.between2("count_fwr_", "_cell").contains('_')
         && Regex::new(vname.between2("count_fwr_", "_cell")).is_ok()
     {
@@ -1287,8 +1287,8 @@ pub fn proc_lvar_auto(
 
         let _exact = format!("{}", mults[u]);
         (String::new(), counts, "cell-exact".to_string())
-    } else if vname.starts_with(&"n_")
-        && vname.after("n_").ends_with(&"")
+    } else if vname.starts_with("n_")
+        && vname.after("n_").ends_with("")
         && (bin_member(
             &ctl.origin_info.dataset_list,
             &vname.between2("n_", "").to_string(),
@@ -1330,8 +1330,8 @@ pub fn proc_lvar_auto(
         }
 
         (format!("{}", count), counts, "cell-exact".to_string())
-    } else if vname.starts_with(&"n_")
-        && vname.after("n_").ends_with(&"_cell")
+    } else if vname.starts_with("n_")
+        && vname.after("n_").ends_with("_cell")
         && (bin_member(
             &ctl.origin_info.dataset_list,
             &vname.between2("n_", "_cell").to_string(),

--- a/enclone_ranger/src/stop.rs
+++ b/enclone_ranger/src/stop.rs
@@ -19,7 +19,7 @@ pub fn main_enclone_stop_ranger(mut inter: EncloneIntermediates) -> Result<(), S
     let drefs = &inter.ex.drefs;
     let gex_info = &inter.setup.gex_info;
     let sr = &inter.ex.sr;
-    let mut fate = &mut inter.ex.fate;
+    let fate = &mut inter.ex.fate;
     let ctl = &inter.setup.ctl;
     let is_bcr = inter.ex.is_bcr;
 
@@ -85,7 +85,7 @@ pub fn main_enclone_stop_ranger(mut inter: EncloneIntermediates) -> Result<(), S
         &mut out_datas,
         &mut tests,
         &mut controls,
-        &mut fate,
+        fate,
     )?;
     Ok(())
 }

--- a/enclone_vars/src/export_code.rs
+++ b/enclone_vars/src/export_code.rs
@@ -28,13 +28,13 @@ fn get_uppers(var: &str) -> Vec<(String, usize)> {
         for i in 0..chars.len() {
             if chars[i].is_ascii_uppercase() {
                 s.push(chars[i]);
-            } else if s.len() > 0 {
+            } else if !s.is_empty() {
                 uppers.push((s.clone(), start));
                 start = i + 1;
                 s.clear();
             }
         }
-        if s.len() > 0 {
+        if !s.is_empty() {
             uppers.push((s, start));
         }
     }
@@ -59,7 +59,7 @@ fn process_var<W: Write>(
     class: &str,
 ) {
     let var = &v.name;
-    let uppers = get_uppers(&var);
+    let uppers = get_uppers(var);
     let mut rega = false;
     let mut dataset = false;
     let mut name = false;
@@ -74,7 +74,7 @@ fn process_var<W: Write>(
             name = true;
         }
     }
-    let upper = uppers.len() > 0;
+    let upper = !uppers.is_empty();
     if !upper || rega || dataset || name || bc || info {
         let mut passes = 1;
         if v.level == "cell-exact" {
@@ -156,7 +156,7 @@ fn run_rustfmt(f: &str) {
 // ...{}...REGA...
 
 fn emit_code_to_test_for_var<W: Write>(var: &str, f: &mut BufWriter<W>, class: &str) {
-    let uppers = get_uppers(&var);
+    let uppers = get_uppers(var);
     let mut rega = None;
     let mut dataset = None;
     let mut name = None;
@@ -269,13 +269,13 @@ fn emit_code_to_test_for_var<W: Write>(var: &str, f: &mut BufWriter<W>, class: &
                 r###"vname.between2("{}", "{}").parse::<i64>().is_ok()"###,
                 begin, end,
             ));
-            if low.len() > 0 {
+            if !low.is_empty() {
                 conditions.push(format!(
                     r###"vname.between2("{}", "{}").force_i64() >= {}"###,
                     begin, end, low,
                 ));
             }
-            if high.len() > 0 {
+            if !high.is_empty() {
                 conditions.push(format!(
                     r###"vname.between2("{}", "{}").force_i64() <= {}"###,
                     begin, end, high,
@@ -306,13 +306,13 @@ fn emit_code_to_test_for_var<W: Write>(var: &str, f: &mut BufWriter<W>, class: &
                 r###"vname.between("{}", "{}").parse::<i64>().is_ok()"###,
                 begin, start,
             ));
-            if low.len() > 0 {
+            if !low.is_empty() {
                 conditions.push(format!(
                     r###"vname.between("{}", "{}").force_i64() >= {}"###,
                     begin, start, low,
                 ));
             }
-            if high.len() > 0 {
+            if !high.is_empty() {
                 conditions.push(format!(
                     r###"vname.between("{}", "{}").force_i64() <= {}"###,
                     begin, start, high,
@@ -364,13 +364,13 @@ fn emit_code_to_test_for_var<W: Write>(var: &str, f: &mut BufWriter<W>, class: &
             r###"vname.between2("{}", "{}").parse::<i64>().is_ok()"###,
             begin, middle,
         ));
-        if low1.len() > 0 {
+        if !low1.is_empty() {
             conditions.push(format!(
                 r###"vname.between2("{}", "{}").force_i64() >= {}"###,
                 begin, middle, low1,
             ));
         }
-        if high1.len() > 0 {
+        if !high1.is_empty() {
             conditions.push(format!(
                 r###"vname.between2("{}", "{}").force_i64() <= {}"###,
                 begin, middle, high1,
@@ -380,13 +380,13 @@ fn emit_code_to_test_for_var<W: Write>(var: &str, f: &mut BufWriter<W>, class: &
             r###"vname.after("{}").between2("{}", "{}").parse::<i64>().is_ok()"###,
             begin, middle, end,
         ));
-        if low2.len() > 0 {
+        if !low2.is_empty() {
             conditions.push(format!(
                 r###"vname.after("{}").between2("{}", "{}").force_i64() >= {}"###,
                 begin, middle, end, low2,
             ));
         }
-        if high2.len() > 0 {
+        if !high2.is_empty() {
             conditions.push(format!(
                 r###"vname.after("{}").between2("{}", "{}").force_i64() <= {}"###,
                 begin, middle, end, high2,
@@ -435,25 +435,25 @@ fn emit_code_to_test_for_var<W: Write>(var: &str, f: &mut BufWriter<W>, class: &
             r###"vname.between("{}", "{}").parse::<i64>().is_ok()"###,
             begin, mid1,
         ));
-        if low1.len() > 0 {
+        if !low1.is_empty() {
             conditions.push(format!(
                 r###"vname.between("{}", "{}").force_i64() >= {}"###,
                 begin, mid1, low1,
             ));
         }
-        if high1.len() > 0 {
+        if !high1.is_empty() {
             conditions.push(format!(
                 r###"vname.between("{}", "{}").force_i64() <= {}"###,
                 begin, mid1, high1,
             ));
         }
-        if low2.len() > 0 {
+        if !low2.is_empty() {
             conditions.push(format!(
                 r###"vname.after("{}").between("{}", "{}").force_i64() >= {}"###,
                 begin, mid1, mid2, low2,
             ));
         }
-        if high2.len() > 0 {
+        if !high2.is_empty() {
             conditions.push(format!(
                 r###"vname.after("{}").between("{}", "{}").force_i64() <= {}"###,
                 begin, mid1, mid2, high2,
@@ -463,13 +463,13 @@ fn emit_code_to_test_for_var<W: Write>(var: &str, f: &mut BufWriter<W>, class: &
             r###"vname.after("{}").after("{}").between("{}", "{}").parse::<i64>().is_ok()"###,
             begin, mid1, mid2, end,
         ));
-        if low3.len() > 0 {
+        if !low3.is_empty() {
             conditions.push(format!(
                 r###"vname.after("{}").after("{}").between("{}", "{}").force_i64() >= {}"###,
                 begin, mid1, mid2, end, low3,
             ));
         }
-        if high3.len() > 0 {
+        if !high3.is_empty() {
             conditions.push(format!(
                 r###"vname.after("{}").after("{}").between("{}", "{}").force_i64() <= {}"###,
                 begin, mid1, mid2, end, high3,
@@ -667,7 +667,7 @@ pub fn export_code(level: usize) -> Vec<(String, String)> {
                 let (mut exact, mut cell) = (String::new(), String::new());
                 let mut code = v.code.clone();
                 parse_value_return_lines(&mut code, &v.level, &mut exact, &mut cell);
-                process_var(&v, &exact, &cell, &code, &mut f, "cvar");
+                process_var(v, &exact, &cell, &code, &mut f, "cvar");
             }
         }
         fwrite!(f, "{}", cvar_vdj_stop);
@@ -838,7 +838,7 @@ pub fn export_code(level: usize) -> Vec<(String, String)> {
                 let (mut exact, mut cell) = (String::new(), String::new());
                 let mut code = v.code.clone();
                 parse_value_return_lines(&mut code, &v.level, &mut exact, &mut cell);
-                process_var(&v, &exact, &cell, &code, &mut f, "lvar");
+                process_var(v, &exact, &cell, &code, &mut f, "lvar");
             }
         }
         fwrite!(f, "{}", lvar_vdj_stop);

--- a/enclone_vars/src/var.rs
+++ b/enclone_vars/src/var.rs
@@ -84,7 +84,7 @@ pub fn parse_variables(input: &str) -> Vec<Variable> {
                     std::process::exit(1);
                 }
                 let n = this_group.len();
-                if !this_group[n - 1].ends_with("\n") {
+                if !this_group[n - 1].ends_with('\n') {
                     this_group[n - 1] += "\n";
                 }
                 this_group[n - 1] += &mut format!(" {}", line.after(INDENT));

--- a/enclone_vars/src/vars
+++ b/enclone_vars/src/vars
@@ -281,23 +281,22 @@ avail:    public
 notes:
 code:     let mut val = String::new();
           for q in 0..ctl.gen_opt.info_fields.len() {
-              if *var == ctl.gen_opt.info_fields[q] {
-                  if ex.share.len() == 2 && ex.share[0].left != ex.share[1].left {
-                      let mut tag = String::new();
-                      for j in 0..ex.share.len() {
-                          if ex.share[j].left {
-                              tag += strme(&ex.share[j].seq);
-                          }
+              if *var == ctl.gen_opt.info_fields[q]
+                  && ex.share.len() == 2 && ex.share[0].left != ex.share[1].left {
+                  let mut tag = String::new();
+                  for j in 0..ex.share.len() {
+                      if ex.share[j].left {
+                          tag += strme(&ex.share[j].seq);
                       }
-                      tag += "_";
-                      for j in 0..ex.share.len() {
-                          if !ex.share[j].left {
-                              tag += strme(&ex.share[j].seq);
-                          }
+                  }
+                  tag += "_";
+                  for j in 0..ex.share.len() {
+                      if !ex.share[j].left {
+                          tag += strme(&ex.share[j].seq);
                       }
-                      if ctl.gen_opt.info_data.contains_key(&tag) {
-                          val = ctl.gen_opt.info_data[&tag][q].clone();
-                      }
+                  }
+                  if ctl.gen_opt.info_data.contains_key(&tag) {
+                      val = ctl.gen_opt.info_data[&tag][q].clone();
                   }
               }
           }
@@ -492,16 +491,14 @@ code:     let x = &ex.share[mid];
                       .to_vec();
                   y = stringme(&aa_seq(&dna, 0));
               }
-          } else {
-              if x.cdr2_start.is_some()
+          } else if x.cdr2_start.is_some()
                   && x.fr3_start.is_some()
                   && x.cdr2_start.unwrap() <= x.fr3_start.unwrap()
-              {
-                  let dna = refdata.refs[x.v_ref_id].to_ascii_vec()
-                      [x.cdr2_start.unwrap()..x.fr3_start.unwrap()]
-                      .to_vec();
-                  y = stringme(&aa_seq(&dna, 0));
-              }
+          {
+              let dna = refdata.refs[x.v_ref_id].to_ascii_vec()
+                  [x.cdr2_start.unwrap()..x.fr3_start.unwrap()]
+                  .to_vec();
+              y = stringme(&aa_seq(&dna, 0));
           }
           exact: y
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -528,16 +525,14 @@ code:     let x = &ex.share[mid];
                       .to_vec();
                   y = stringme(&dna);
               }
-          } else {
-              if x.cdr2_start.is_some()
+          } else if x.cdr2_start.is_some()
                   && x.fr3_start.is_some()
                   && x.cdr2_start.unwrap() <= x.fr3_start.unwrap()
-              {
-                  let dna = refdata.refs[x.v_ref_id].to_ascii_vec()
-                      [x.cdr2_start.unwrap()..x.fr3_start.unwrap()]
-                      .to_vec();
-                  y = stringme(&dna);
-              }
+          {
+              let dna = refdata.refs[x.v_ref_id].to_ascii_vec()
+                  [x.cdr2_start.unwrap()..x.fr3_start.unwrap()]
+                  .to_vec();
+              y = stringme(&dna);
           }
           exact: y
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -556,12 +551,12 @@ code:     let x = &ex.share[mid];
           let mut y = "unknown".to_string();
           let c;
           if arg1 == 1 {
-              c = get_cdr1(&x, 0, 0);
+              c = get_cdr1(x, 0, 0);
               if c.is_some() {
                   y = stringme(&aa_seq(c.unwrap().as_bytes(), 0));
               }
           } else if arg1 == 2 {
-              c = get_cdr2(&x, 0, 0);
+              c = get_cdr2(x, 0, 0);
               if c.is_some() {
                   y = stringme(&aa_seq(c.unwrap().as_bytes(), 0));
               }
@@ -590,7 +585,7 @@ code:     let x = &ex.share[mid];
                   left = 3;
                   right = 3;
               }
-              c = get_cdr1(&x, left, right);
+              c = get_cdr1(x, left, right);
               if c.is_some() {
                   y = stringme(&aa_seq(c.unwrap().as_bytes(), 0));
               }
@@ -603,12 +598,12 @@ code:     let x = &ex.share[mid];
                   left = 1;
                   right = 0;
               }
-              c = get_cdr2(&x, left, right);
+              c = get_cdr2(x, left, right);
               if c.is_some() {
                   y = stringme(&aa_seq(c.unwrap().as_bytes(), 0));
               }
           } else {
-              c = get_cdr3(&x, -1, -1);
+              c = get_cdr3(x, -1, -1);
               if c.is_some() {
                   y = stringme(&aa_seq(c.unwrap().as_bytes(), 0));
               }
@@ -634,67 +629,13 @@ code:     let (left, right) = (arg2 * 3, arg3 * 3);
               if x.cdr1_start.is_some()
                   && x.fr2_start.is_some()
                   && x.cdr1_start.unwrap() <= x.fr2_start.unwrap()
+                  && x.cdr1_start.unwrap() as i64 - left >= 0
+                  && x.cdr1_start.unwrap() as i64 - left < x.seq_del_amino.len() as i64
+                  && x.fr2_start.unwrap() as i64 + right > 0
+                  && x.fr2_start.unwrap() as i64 + right <= x.seq_del_amino.len() as i64
               {
-                  if x.cdr1_start.unwrap() as i64 - left >= 0
-                      && x.cdr1_start.unwrap() as i64 - left < x.seq_del_amino.len() as i64
-                      && x.fr2_start.unwrap() as i64 + right > 0
-                      && x.fr2_start.unwrap() as i64 + right <= x.seq_del_amino.len() as i64
-                  {
-                      for p in x.cdr1_start.unwrap() as i64 - left..
-                          x.fr2_start.unwrap() as i64 + right {
-                          let p = p as usize;
-                          for j in 0..x.ins.len() {
-                              if x.ins[j].0 == p {
-                                  let mut z = x.ins[j].1.clone();
-                                  dna.append(&mut z);
-                              }
-                          }
-                          if x.seq_del_amino[p] != b'-' {
-                              dna.push(x.seq_del_amino[p]);
-                          }
-                      }
-                      test_internal_error_seq(&x.seq, &dna, &x.cdr3_aa)?;
-                      y = stringme(&aa_seq(&dna, 0));
-                  }
-              }
-          } else if arg1 == 2 {
-              if x.cdr2_start.is_some()
-                  && x.fr3_start.is_some()
-                  && x.cdr2_start.unwrap() <= x.fr3_start.unwrap()
-              {
-                  if x.cdr2_start.unwrap() as i64 - left >= 0
-                      && x.cdr2_start.unwrap() as i64 - left < x.seq_del_amino.len() as i64
-                      && x.fr3_start.unwrap() as i64 + right > 0
-                      && x.fr3_start.unwrap() as i64 + right <= x.seq_del_amino.len() as i64
-                  {
-                      for p in x.cdr2_start.unwrap() as i64 - left..
-                          x.fr3_start.unwrap() as i64 + right {
-                          let p = p as usize;
-                          for j in 0..x.ins.len() {
-                              if x.ins[j].0 == p {
-                                  let mut z = x.ins[j].1.clone();
-                                  dna.append(&mut z);
-                              }
-                          }
-                          if x.seq_del_amino[p] != b'-' {
-                              dna.push(x.seq_del_amino[p]);
-                          }
-                      }
-                      test_internal_error_seq(&x.seq, &dna, &x.cdr3_aa)?;
-                      y = stringme(&aa_seq(&dna, 0));
-                  }
-              }
-          } else {
-              if x.cdr3_start as i64 - left >= 0
-                  && x.cdr3_start as i64 - left < x.seq_del_amino.len() as i64
-                  && x.cdr3_start as i64 + 3 * x.cdr3_aa.len() as i64 + right > 0
-                  && x.cdr3_start as i64 + 3 * x.cdr3_aa.len() as i64 + right
-                      <= x.seq_del_amino.len() as i64
-              {
-                  for p in
-                      x.cdr3_start as i64 - left..
-                          x.cdr3_start as i64 + 3 * x.cdr3_aa.len() as i64 + right
-                  {
+                  for p in x.cdr1_start.unwrap() as i64 - left..
+                      x.fr2_start.unwrap() as i64 + right {
                       let p = p as usize;
                       for j in 0..x.ins.len() {
                           if x.ins[j].0 == p {
@@ -709,6 +650,54 @@ code:     let (left, right) = (arg2 * 3, arg3 * 3);
                   test_internal_error_seq(&x.seq, &dna, &x.cdr3_aa)?;
                   y = stringme(&aa_seq(&dna, 0));
               }
+          } else if arg1 == 2 {
+              if x.cdr2_start.is_some()
+                  && x.fr3_start.is_some()
+                  && x.cdr2_start.unwrap() <= x.fr3_start.unwrap()
+                  && x.cdr2_start.unwrap() as i64 - left >= 0
+                  && x.cdr2_start.unwrap() as i64 - left < x.seq_del_amino.len() as i64
+                  && x.fr3_start.unwrap() as i64 + right > 0
+                  && x.fr3_start.unwrap() as i64 + right <= x.seq_del_amino.len() as i64
+              {
+                  for p in x.cdr2_start.unwrap() as i64 - left..
+                      x.fr3_start.unwrap() as i64 + right {
+                      let p = p as usize;
+                      for j in 0..x.ins.len() {
+                          if x.ins[j].0 == p {
+                              let mut z = x.ins[j].1.clone();
+                              dna.append(&mut z);
+                          }
+                      }
+                      if x.seq_del_amino[p] != b'-' {
+                          dna.push(x.seq_del_amino[p]);
+                      }
+                  }
+                  test_internal_error_seq(&x.seq, &dna, &x.cdr3_aa)?;
+                  y = stringme(&aa_seq(&dna, 0));
+              }
+          } else if x.cdr3_start as i64 - left >= 0
+              && x.cdr3_start as i64 - left < x.seq_del_amino.len() as i64
+              && x.cdr3_start as i64 + 3 * x.cdr3_aa.len() as i64 + right > 0
+              && x.cdr3_start as i64 + 3 * x.cdr3_aa.len() as i64 + right
+                  <= x.seq_del_amino.len() as i64
+          {
+              for p in
+                  x.cdr3_start as i64 - left..
+                      x.cdr3_start as i64 + 3 * x.cdr3_aa.len() as i64 + right
+              {
+                  let p = p as usize;
+                  for j in 0..x.ins.len() {
+                      if x.ins[j].0 == p {
+                          let mut z = x.ins[j].1.clone();
+                          dna.append(&mut z);
+                      }
+                  }
+                  if x.seq_del_amino[p] != b'-' {
+                      dna.push(x.seq_del_amino[p]);
+                  }
+              }
+              test_internal_error_seq(&x.seq, &dna, &x.cdr3_aa)?;
+              y = stringme(&aa_seq(&dna, 0));
           }
           exact: y
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -727,9 +716,9 @@ code:     let x = &ex.share[mid];
           let mut y = "unknown".to_string();
           let c;
           if arg1 == 1 {
-              c = get_cdr1(&x, 0, 0);
+              c = get_cdr1(x, 0, 0);
           } else if arg1 == 2 {
-              c = get_cdr2(&x, 0, 0);
+              c = get_cdr2(x, 0, 0);
           } else {
               c = Some(x.cdr3_dna.clone());
           }
@@ -753,9 +742,9 @@ code:     let x = &ex.share[mid];
           let mut y = "unknown".to_string();
           let c;
           if arg1 == 1 {
-              c = get_cdr1(&x, 0, 0);
+              c = get_cdr1(x, 0, 0);
           } else if arg1 == 2 {
-              c = get_cdr2(&x, 0, 0);
+              c = get_cdr2(x, 0, 0);
           } else {
               c = Some(x.cdr3_dna.clone());
           }
@@ -880,7 +869,7 @@ brief:    CDR3 complexity number
 page:     enclone help cvars
 avail:    public
 notes:
-code:     let (comp, _edit) = comp_edit(&ex, mid, col, &refdata, &dref, &rsi);
+code:     let (comp, _edit) = comp_edit(ex, mid, col, refdata, dref, rsi);
           exact: format!("{}", comp)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 name:     const
@@ -1682,7 +1671,7 @@ brief:    edit versus reference CDR3
 page:     enclone help cvars
 avail:    public
 notes:
-code:     let (_comp, edit) = comp_edit(&ex, mid, col, &refdata, &dref, &rsi);
+code:     let (_comp, edit) = comp_edit(ex, mid, col, refdata, dref, rsi);
           exact: edit
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 name:     entropy
@@ -1955,17 +1944,17 @@ code:     let x = &ex.share[mid];
           let mut y = "unknown".to_string();
           let c;
           if arg1 == 1 {
-              c = get_fwr1(&x);
+              c = get_fwr1(x);
           } else if arg1 == 2 {
-              c = get_fwr2(&x);
+              c = get_fwr2(x);
           } else if arg1 == 3 {
-              c = get_fwr3(&x);
+              c = get_fwr3(x);
           } else {
               let x = &ex.share[mid];
               let start = rsi.cdr3_starts[col] + 3 * rsi.cdr3_lens[col];
               let stop = rsi.seq_del_lens[col];
               let dna = &x.seq_del_amino[start..stop];
-              c = Some(stringme(&dna));
+              c = Some(stringme(dna));
           }
           if c.is_some() {
               y = stringme(&aa_seq(c.unwrap().as_bytes(), 0));
@@ -2036,17 +2025,17 @@ code:     let x = &ex.share[mid];
           let mut y = "unknown".to_string();
           let c;
           if arg1 == 1 {
-              c = get_fwr1(&x);
+              c = get_fwr1(x);
           } else if arg1 == 2 {
-              c = get_fwr2(&x);
+              c = get_fwr2(x);
           } else if arg1 == 3 {
-              c = get_fwr3(&x);
+              c = get_fwr3(x);
           } else {
               let x = &ex.share[mid];
               let start = rsi.cdr3_starts[col] + 3 * rsi.cdr3_lens[col];
               let stop = rsi.seq_del_lens[col];
               let dna = &x.seq_del_amino[start..stop];
-              c = Some(stringme(&dna));
+              c = Some(stringme(dna));
           }
           if c.is_some() {
               y = c.unwrap();
@@ -2117,17 +2106,17 @@ code:     let x = &ex.share[mid];
           let mut y = "unknown".to_string();
           let c;
           if arg1 == 1 {
-              c = get_fwr1(&x);
+              c = get_fwr1(x);
           } else if arg1 == 2 {
-              c = get_fwr2(&x);
+              c = get_fwr2(x);
           } else if arg1 == 3 {
-              c = get_fwr3(&x);
+              c = get_fwr3(x);
           } else {
               let x = &ex.share[mid];
               let start = rsi.cdr3_starts[col] + 3 * rsi.cdr3_lens[col];
               let stop = rsi.seq_del_lens[col];
               let dna = &x.seq_del_amino[start..stop];
-              c = Some(stringme(&dna));
+              c = Some(stringme(dna));
           }
           if c.is_some() {
               y = format!("{}", c.unwrap().len() / 3);
@@ -2633,7 +2622,7 @@ notes:
 code:     let mut nbc = Vec::<String>::new();
           for j in 0..ex.clones.len() {
               let bc = ex.clones[j][0].barcode.before("-").as_bytes();
-              let mut n = 0 as u64;
+              let mut n = 0_u64;
               for k in 0..bc.len() {
                   if k > 0 {
                       n *= 4;
@@ -3220,7 +3209,7 @@ code:     let mut numis = Vec::<usize>::new();
           for j in 0..ex.clones.len() {
               numis.push(ex.clones[j][mid].umi_count);
           }
-          numis.sort();
+          numis.sort_unstable();
           exact: format!("{}", numis.iter().max().unwrap())
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 name:     u_mean
@@ -3238,7 +3227,7 @@ code:     let mut numis = Vec::<usize>::new();
           for j in 0..ex.clones.len() {
               numis.push(ex.clones[j][mid].umi_count);
           }
-          numis.sort();
+          numis.sort_unstable();
           let utot: usize = numis.iter().sum();
           let u_mean = (utot as f64 / numis.len() as f64).round() as usize;
           exact: format!("{}", u_mean)
@@ -3258,7 +3247,7 @@ code:     let mut numis = Vec::<usize>::new();
           for j in 0..ex.clones.len() {
               numis.push(ex.clones[j][mid].umi_count);
           }
-          numis.sort();
+          numis.sort_unstable();
           exact: format!("{}", numis.iter().min().unwrap())
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 name:     u_sum
@@ -3312,7 +3301,7 @@ code:     let mut numis = Vec::<usize>::new();
           for j in 0..ex.clones.len() {
               numis.push(ex.clones[j][mid].umi_count);
           }
-          numis.sort();
+          numis.sort_unstable();
           let utot: usize = numis.iter().sum();
           let u_mean = (utot as f64 / numis.len() as f64).round() as usize;
           exact: format!("{}", u_mean)


### PR DESCRIPTION
Only touch enclone_ranger and its dependencies, revert the rest.

These automated fixups help with a bunch of run-time and compiile-time
inefficiencies.