### PR TITLE
move quality score filtering to earlier point in code

### DIFF
--- a/enclone_exec/tests/enclone_test4.rs
+++ b/enclone_exec/tests/enclone_test4.rs
@@ -95,7 +95,7 @@ fn test_cpu_usage() {
             gi = line.force_f64() / 1_000_000_000.0;
         }
     }
-    const REQUIRED_GI: f64 = 55.9803;
+    const REQUIRED_GI: f64 = 56.1362;
     let err = ((gi - REQUIRED_GI) / REQUIRED_GI).abs();
     let report = format!(
         "Observed GI = {:.4}, versus required GI = {:.4}, err = {:.2}%, versus max \

--- a/enclone_print/src/print_clonotypes.rs
+++ b/enclone_print/src/print_clonotypes.rs
@@ -138,13 +138,6 @@ pub fn print_clonotypes(
         }
     }
 
-    // Compute total cells.
-
-    let mut total_cells = 0;
-    for i in 0..exact_clonotypes.len() {
-        total_cells += exact_clonotypes[i].ncells();
-    }
-
     // Test for presence of GEX/FB data.
 
     let mut have_gex = false;
@@ -424,12 +417,9 @@ pub fn print_clonotypes(
                         ctl,
                         &exacts,
                         exact_clonotypes,
-                        total_cells,
                         mat,
                         refdata,
-                        &vars,
                         &mut bads,
-                        &mut res.11,
                     );
                 }
 

--- a/enclone_print/src/print_clonotypes.rs
+++ b/enclone_print/src/print_clonotypes.rs
@@ -104,6 +104,7 @@ pub fn print_clonotypes(
 
     let mut parseable_fields = Vec::<String>::new();
     let mut max_chains = 4;
+    // This seems like a bug, since rsi is uninitialized upon entry to print_clonotypes.
     for i in 0..rsi.len() {
         max_chains = max(max_chains, rsi[i].mat.len());
     }

--- a/enclone_print/src/print_clonotypes.rs
+++ b/enclone_print/src/print_clonotypes.rs
@@ -413,14 +413,7 @@ pub fn print_clonotypes(
                 // Mark some weak exact subclonotypes for deletion.
 
                 if pass == 1 {
-                    delete_weaks(
-                        ctl,
-                        &exacts,
-                        exact_clonotypes,
-                        mat,
-                        refdata,
-                        &mut bads,
-                    );
+                    delete_weaks(ctl, &exacts, exact_clonotypes, mat, refdata, &mut bads);
                 }
 
                 // Done unless on second pass.  Unless there are bounds or COMPLETE specified

--- a/enclone_print/src/print_utils5.rs
+++ b/enclone_print/src/print_utils5.rs
@@ -273,6 +273,7 @@ pub fn delete_weaks(
     // doesn't occur as Q40 twice, and disagrees with the reference.
 
     let cols = mat.len();
+    /*
     // (column, pos, base, qual, row)
     let mut vquals = Vec::<(usize, usize, u8, u8, usize)>::new();
     for u in 0..nexacts {
@@ -348,6 +349,7 @@ pub fn delete_weaks(
         }
         j = k;
     }
+    */
 
     // Remove onesies that do not have an exact match.
 

--- a/enclone_print/src/print_utils5.rs
+++ b/enclone_print/src/print_utils5.rs
@@ -193,12 +193,9 @@ pub fn delete_weaks(
     ctl: &EncloneControl,
     exacts: &Vec<usize>,
     exact_clonotypes: &Vec<ExactClonotype>,
-    _total_cells: usize,
     mat: &Vec<Vec<Option<usize>>>,
     refdata: &RefData,
-    _vars: &Vec<Vec<usize>>,
     bads: &mut Vec<bool>,
-    _fate: &mut Vec<(usize, String, String)>,
 ) {
     // Mark for deletion exact subclonotypes that fail the MIN_CELLS_EXACT or MIN_CHAINS_EXACT
     // or CHAINS_EXACT tests.

--- a/enclone_print/src/print_utils5.rs
+++ b/enclone_print/src/print_utils5.rs
@@ -196,9 +196,9 @@ pub fn delete_weaks(
     _total_cells: usize,
     mat: &Vec<Vec<Option<usize>>>,
     refdata: &RefData,
-    vars: &Vec<Vec<usize>>,
+    _vars: &Vec<Vec<usize>>,
     bads: &mut Vec<bool>,
-    fate: &mut Vec<(usize, String, String)>,
+    _fate: &mut Vec<(usize, String, String)>,
 ) {
     // Mark for deletion exact subclonotypes that fail the MIN_CELLS_EXACT or MIN_CHAINS_EXACT
     // or CHAINS_EXACT tests.
@@ -268,91 +268,9 @@ pub fn delete_weaks(
         }
     }
 
-    // Find and mark for deletion exact subclonotypes having a variant base in V..J that,
-    // accounting for all the cells in all the exact subclonotypes, never occurs as Q60
-    // doesn't occur as Q40 twice, and disagrees with the reference.
-
-    let cols = mat.len();
-    /*
-    // (column, pos, base, qual, row)
-    let mut vquals = Vec::<(usize, usize, u8, u8, usize)>::new();
-    for u in 0..nexacts {
-        let clonotype_id = exacts[u];
-        let ex = &exact_clonotypes[clonotype_id];
-        for col in 0..cols {
-            let m = mat[col][u];
-            if m.is_some() {
-                let m = m.unwrap();
-                if ex.share[m].annv.len() > 1 {
-                    continue;
-                }
-                let n = ex.share[m].seq_del.len();
-                let vref = &exact_clonotypes[exacts[u]].share[m].vs.to_ascii_vec();
-                let jref = &exact_clonotypes[exacts[u]].share[m].js.to_ascii_vec();
-                for z in 0..vars[col].len() {
-                    let p = vars[col][z];
-                    let b = ex.share[m].seq_del[p];
-                    let mut refdiff = false;
-                    if p < vref.len() - ctl.heur.ref_v_trim && b != vref[p] {
-                        refdiff = true;
-                    }
-                    if p >= n - (jref.len() - ctl.heur.ref_j_trim)
-                        && b != jref[jref.len() - (n - p)]
-                    {
-                        refdiff = true;
-                    }
-                    if refdiff {
-                        for j in 0..ex.clones.len() {
-                            let qual = ex.clones[j][m].quals[p];
-                            vquals.push((col, p, b, qual, u));
-                        }
-                    }
-                }
-            }
-        }
-    }
-    vquals.sort_unstable();
-    let mut j = 0;
-    while j < vquals.len() {
-        let mut k = j + 1;
-        while k < vquals.len() {
-            if vquals[k].0 != vquals[j].0
-                || vquals[k].1 != vquals[j].1
-                || vquals[k].2 != vquals[j].2
-            {
-                break;
-            }
-            k += 1;
-        }
-        let mut q60 = false;
-        let mut q40 = 0;
-        for m in j..k {
-            if vquals[m].3 >= 60 {
-                q60 = true;
-            } else if vquals[m].3 >= 40 {
-                q40 += 1;
-            }
-        }
-        if !q60 && q40 < 2 {
-            let u = vquals[j].4;
-            if ctl.clono_filt_opt.qual_filter {
-                bads[u] = true;
-            }
-            let ex = &exact_clonotypes[exacts[u]];
-            for i in 0..ex.ncells() {
-                fate.push((
-                    ex.clones[i][0].dataset_index,
-                    ex.clones[i][0].barcode.clone(),
-                    "failed QUAL filter".to_string(),
-                ));
-            }
-        }
-        j = k;
-    }
-    */
-
     // Remove onesies that do not have an exact match.
 
+    let cols = mat.len();
     if cols > 1 {
         for u1 in 0..nexacts {
             let ex1 = &exact_clonotypes[exacts[u1]];

--- a/enclone_stuff/src/some_filters.rs
+++ b/enclone_stuff/src/some_filters.rs
@@ -6,12 +6,15 @@ use crate::split_orbits::split_orbits;
 use crate::weak_chains::weak_chains;
 use enclone_core::defs::{CloneInfo, EncloneControl, ExactClonotype};
 use enclone_print::define_mat::define_mat;
+use enclone_print::print_utils3::define_column_info;
 use equiv::EquivRel;
 use qd::Double;
 use rayon::prelude::*;
+use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::time::Instant;
-use vector_utils::{erase_if, next_diff12_3, next_diff1_2};
+use vdj_ann::refx::RefData;
+use vector_utils::{erase_if, next_diff12_3, next_diff1_2, unique_sort};
 
 pub fn some_filters(
     orbits: &mut Vec<Vec<i32>>,
@@ -25,6 +28,7 @@ pub fn some_filters(
     eq: &EquivRel,
     disintegrated: &Vec<bool>,
     fate: &mut Vec<HashMap<String, String>>,
+    refdata: &RefData,
 ) {
     // Delete exact subclonotypes that appear to represent doublets.
 
@@ -241,4 +245,171 @@ pub fn some_filters(
         raw_joins,
     );
     ctl.perf_stats(&tsplit, "splitting orbits 2");
+
+    // Find and mark for deletion exact subclonotypes having a variant base in V..J that,
+    // accounting for all the cells in all the exact subclonotypes, never occurs as Q60
+    // doesn't occur as Q40 twice, and disagrees with the reference.
+
+    let mut results = Vec::<(usize, Vec<(usize, String, String)>, Vec<usize>)>::new();
+    for i in 0..orbits.len() {
+        results.push((i, Vec::new(), Vec::new()));
+    }
+    results.par_iter_mut().for_each(|res| {
+        let i = res.0;
+        let o = orbits[i].clone();
+        let mut od = Vec::<(Vec<usize>, usize, i32)>::new();
+        for id in o.iter() {
+            let x: &CloneInfo = &info[*id as usize];
+            od.push((x.origin.clone(), x.clonotype_id, *id));
+        }
+        od.sort();
+        let mut exacts = Vec::<usize>::new();
+        let mut j = 0;
+        while j < od.len() {
+            let k = next_diff12_3(&od, j as i32) as usize;
+            exacts.push(od[j].1);
+            j = k;
+        }
+        let mat = define_mat(
+            is_bcr,
+            to_bc,
+            sr,
+            ctl,
+            exact_clonotypes,
+            &exacts,
+            &od,
+            info,
+            raw_joins,
+        );
+        let cols = mat.len();
+        let rsi = define_column_info(ctl, &exacts, exact_clonotypes, &mat, refdata);
+
+        // Create vars, copied from vars_and_shares.
+
+        let mut vars = Vec::<Vec<usize>>::new();
+        for cx in 0..cols {
+            let mut n = 0;
+            for z in 0..rsi.seqss[cx].len() {
+                n = max(n, rsi.seqss[cx][z].len());
+            }
+            let mut v = Vec::<usize>::new();
+            for p in 0..n {
+                let mut bases = Vec::<u8>::new();
+                for s in 0..rsi.seqss[cx].len() {
+                    if p >= rsi.seqss[cx][s].len() {
+                        continue;
+                    }
+                    bases.push(rsi.seqss[cx][s][p]);
+                }
+                unique_sort(&mut bases);
+                if bases.len() > 1 {
+                    v.push(p);
+                }
+            }
+            vars.push(v);
+        }
+
+        // Proceed.
+
+        // (column, pos, base, qual, row)
+        let mut vquals = Vec::<(usize, usize, u8, u8, usize)>::new();
+        for u in 0..exacts.len() {
+            let clonotype_id = exacts[u];
+            let ex = &exact_clonotypes[clonotype_id];
+            for col in 0..cols {
+                let m = mat[col][u];
+                if m.is_some() {
+                    let m = m.unwrap();
+                    if ex.share[m].annv.len() > 1 {
+                        continue;
+                    }
+                    let n = ex.share[m].seq_del.len();
+                    let vref = &exact_clonotypes[exacts[u]].share[m].vs.to_ascii_vec();
+                    let jref = &exact_clonotypes[exacts[u]].share[m].js.to_ascii_vec();
+                    for z in 0..vars[col].len() {
+                        let p = vars[col][z];
+                        let b = ex.share[m].seq_del[p];
+                        let mut refdiff = false;
+                        if p < vref.len() - ctl.heur.ref_v_trim && b != vref[p] {
+                            refdiff = true;
+                        }
+                        if p >= n - (jref.len() - ctl.heur.ref_j_trim)
+                            && b != jref[jref.len() - (n - p)]
+                        {
+                            refdiff = true;
+                        }
+                        if refdiff {
+                            for j in 0..ex.clones.len() {
+                                let qual = ex.clones[j][m].quals[p];
+                                vquals.push((col, p, b, qual, u));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        vquals.sort_unstable();
+        let mut j = 0;
+        while j < vquals.len() {
+            let mut k = j + 1;
+            while k < vquals.len() {
+                if vquals[k].0 != vquals[j].0
+                    || vquals[k].1 != vquals[j].1
+                    || vquals[k].2 != vquals[j].2
+                {
+                    break;
+                }
+                k += 1;
+            }
+            let mut q60 = false;
+            let mut q40 = 0;
+            for m in j..k {
+                if vquals[m].3 >= 60 {
+                    q60 = true;
+                } else if vquals[m].3 >= 40 {
+                    q40 += 1;
+                }
+            }
+            if !q60 && q40 < 2 {
+                let u = vquals[j].4;
+                if ctl.clono_filt_opt.qual_filter {
+                    res.2.push(exacts[u]);
+                }
+                let ex = &exact_clonotypes[exacts[u]];
+                for i in 0..ex.ncells() {
+                    res.1.push((
+                        ex.clones[i][0].dataset_index,
+                        ex.clones[i][0].barcode.clone(),
+                        "failed QUAL filter".to_string(),
+                    ));
+                }
+            }
+            j = k;
+        }
+    });
+    let mut to_delete = vec![false; exact_clonotypes.len()];
+    let mut dels = Vec::<i32>::new();
+    for i in 0..results.len() {
+        for j in 0..results[i].1.len() {
+            fate[results[i].1[j].0].insert(results[i].1[j].1.clone(), results[i].1[j].2.clone());
+        }
+        for x in results[i].2.iter() {
+            to_delete[*x] = true;
+        }
+    }
+    dels.sort_unstable();
+    let mut orbits2 = Vec::<Vec<i32>>::new();
+    for i in 0..orbits.len() {
+        let mut o = orbits[i].clone();
+        let mut del = vec![false; o.len()];
+        for j in 0..o.len() {
+            let id = info[o[j] as usize].clonotype_index;
+            if to_delete[id] {
+                del[j] = true;
+            }
+        }
+        erase_if(&mut o, &del);
+        orbits2.push(o);
+    }
+    *orbits = orbits2;
 }

--- a/enclone_stuff/src/start.rs
+++ b/enclone_stuff/src/start.rs
@@ -539,6 +539,7 @@ pub fn main_enclone_start(setup: EncloneSetup) -> Result<EncloneIntermediates, S
         &eq,
         &disintegrated,
         &mut fate,
+        refdata,
     );
 
     // Mark VDJ noncells.

--- a/img/two_genes.svg
+++ b/img/two_genes.svg
@@ -604,6 +604,7 @@ HLA-A_g
 <circle cx="110" cy="523" r="4" opacity="1" fill="#FF0000" stroke="none" stroke-width="1"/>
 <circle cx="761" cy="277" r="4" opacity="1" fill="#FF0000" stroke="none" stroke-width="1"/>
 <circle cx="113" cy="522" r="4" opacity="1" fill="#FF0000" stroke="none" stroke-width="1"/>
+<circle cx="214" cy="453" r="4" opacity="1" fill="#FF0000" stroke="none" stroke-width="1"/>
 <circle cx="120" cy="521" r="4" opacity="1" fill="#FF0000" stroke="none" stroke-width="1"/>
 <circle cx="660" cy="273" r="4" opacity="1" fill="#FF0000" stroke="none" stroke-width="1"/>
 <circle cx="214" cy="460" r="4" opacity="1" fill="#FF0000" stroke="none" stroke-width="1"/>

--- a/test
+++ b/test
@@ -132,7 +132,7 @@ set elapsed = `expr $end - $start`
 ##### FAIL IF TOO MUCH TIME USED #####
 
 echo "\ntest compile time = $compile_elapsed seconds"
-set expected = 110
+set expected = 115
 set fudge_num = 11
 set fudge_den = 10
 set expected_plus_times = `expr $expected \* $fudge_num`


### PR DESCRIPTION
The reason for doing this is that now all the filtering steps come before print_clonotypes,
and this makes the code more flexible (enabling changes yet to come).  In principle this
could change results however this was not observed.

STATUS: ./test, enclone.test and test_vis pass.  