### PR TITLE
symlink licenses into crate directories.

### DIFF
--- a/enclone/Cargo.toml
+++ b/enclone/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license-file = "../LICENSE.txt"
+license-file = "LICENSE.txt"
 publish = false
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml

--- a/enclone/LICENSE.txt
+++ b/enclone/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/enclone_args/Cargo.toml
+++ b/enclone_args/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license-file = "../LICENSE.txt"
+license-file = "LICENSE.txt"
 publish = false
 
 # This crate is for preprocessing including argument processing and initial reading/testing of

--- a/enclone_args/LICENSE.txt
+++ b/enclone_args/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/enclone_com/Cargo.toml
+++ b/enclone_com/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license-file = "../LICENSE.txt"
+license-file = "LICENSE.txt"
 publish = false
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml

--- a/enclone_com/LICENSE.txt
+++ b/enclone_com/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/enclone_core/Cargo.toml
+++ b/enclone_core/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
 build = "build.rs"
-license-file = "../LICENSE.txt"
+license-file = "LICENSE.txt"
 publish = false
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml

--- a/enclone_core/LICENSE.txt
+++ b/enclone_core/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/enclone_exec/Cargo.toml
+++ b/enclone_exec/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license-file = "../LICENSE.txt"
+license-file = "LICENSE.txt"
 publish = false
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml

--- a/enclone_exec/LICENSE.txt
+++ b/enclone_exec/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/enclone_help/Cargo.toml
+++ b/enclone_help/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license-file = "../LICENSE.txt"
+license-file = "LICENSE.txt"
 publish = false
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml

--- a/enclone_help/LICENSE.txt
+++ b/enclone_help/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/enclone_main/Cargo.toml
+++ b/enclone_main/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license-file = "../LICENSE.txt"
+license-file = "LICENSE.txt"
 publish = false
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml

--- a/enclone_main/LICENSE.txt
+++ b/enclone_main/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/enclone_print/Cargo.toml
+++ b/enclone_print/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license-file = "../LICENSE.txt"
+license-file = "LICENSE.txt"
 publish = false
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml

--- a/enclone_print/LICENSE.txt
+++ b/enclone_print/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/enclone_proto/Cargo.toml
+++ b/enclone_proto/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license-file = "../LICENSE.txt"
+license-file = "LICENSE.txt"
 publish = false
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml

--- a/enclone_proto/LICENSE.txt
+++ b/enclone_proto/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/enclone_ranger/Cargo.toml
+++ b/enclone_ranger/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license-file = "../LICENSE.txt"
+license-file = "LICENSE.txt"
 publish = false
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml

--- a/enclone_ranger/LICENSE.txt
+++ b/enclone_ranger/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/enclone_stuff/Cargo.toml
+++ b/enclone_stuff/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license-file = "../LICENSE.txt"
+license-file = "LICENSE.txt"
 publish = false
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml

--- a/enclone_stuff/LICENSE.txt
+++ b/enclone_stuff/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/enclone_tail/Cargo.toml
+++ b/enclone_tail/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license-file = "../LICENSE.txt"
+license-file = "LICENSE.txt"
 publish = false
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml

--- a/enclone_tail/LICENSE.txt
+++ b/enclone_tail/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/enclone_tools/Cargo.toml
+++ b/enclone_tools/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license-file = "../LICENSE.txt"
+license-file = "LICENSE.txt"
 publish = false
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml

--- a/enclone_tools/LICENSE.txt
+++ b/enclone_tools/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/enclone_vars/Cargo.toml
+++ b/enclone_vars/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license-file = "../LICENSE.txt"
+license-file = "LICENSE.txt"
 publish = false
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml

--- a/enclone_vars/LICENSE.txt
+++ b/enclone_vars/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/enclone_version/Cargo.toml
+++ b/enclone_version/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license-file = "../LICENSE.txt"
+license-file = "LICENSE.txt"
 publish = false
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml

--- a/enclone_version/LICENSE.txt
+++ b/enclone_version/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/enclone_versions/Cargo.toml
+++ b/enclone_versions/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license-file = "../LICENSE.txt"
+license-file = "LICENSE.txt"
 publish = false
 
 [dependencies]

--- a/enclone_versions/LICENSE.txt
+++ b/enclone_versions/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/enclone_visual/Cargo.toml
+++ b/enclone_visual/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license-file = "../LICENSE.txt"
+license-file = "LICENSE.txt"
 publish = false
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml

--- a/enclone_visual/LICENSE.txt
+++ b/enclone_visual/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt

--- a/scroll_crash/Cargo.toml
+++ b/scroll_crash/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
               Patrick Marks <patrick.marks@10xgenomics.com>,
               Wyatt McDonnell <wyatt.mcdonnell@10xgenomics.com>"""]
 edition = "2018"
-license-file = "../LICENSE.txt"
+license-file = "LICENSE.txt"
 publish = false
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml

--- a/scroll_crash/LICENSE.txt
+++ b/scroll_crash/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt


### PR DESCRIPTION
Otherwise the license files don't show up when the crate is vendored,
which poses problems for downstream license tooling.  It would also be a
problem if we ever wanted to publish any of these.