### PR TITLE
various changes (= dj/339)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,6 +30,10 @@ jobs:
       - name: Checkout enclone master
         uses: actions/checkout@master
 
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ matrix.style }}v1 # increment this to bust the cache if needed
+
       # set up caching (duplicated verbatim below)
       #
       # We have observed that Mac builds on GitHub Actions sometimes fail with errors about 
@@ -40,29 +44,12 @@ jobs:
       # phenotype.  Now turned off.
       #
       # 2. We turned off the caching.  This seems to have solved the problem.
+      #
+      # THIS IS A NEW VERSION.  MAYBE IT WILL WORK.
 
-      # - name: purge
-      #   run: sudo /usr/sbin/purge
-      # - name: Cache cargo registry
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ~/.cargo/registry
-      #     key: ${{runner.os}}-cargo-registry-${{hashFiles('Cargo.lock')}}
-      #     restore-keys: ${{runner.os}}-cargo-registry-
-      # - name: Cache cargo git index
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ~/.cargo/git
-      #     key: ${{runner.os}}-cargo-git-${{hashFiles('Cargo.lock')}}
-      #     restore-keys: ${{runner.os}}-cargo-git-
-      # - name: Cache cargo build
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: target
-      #     key: ${{runner.os}}-cargo-target-${{hashFiles('Cargo.lock')}}-${{hashFiles('**/Cargo.toml')}}-${{hashFiles('**/*.rs')}}
-      #     restore-keys: |
-      #       ${{runner.os}}-cargo-target-${{hashFiles('Cargo.lock')}}-
-      #       ${{runner.os}}-cargo-target-
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ matrix.style }}v1 # increment this to bust the cache if needed
 
       # start the real work
 
@@ -99,26 +86,9 @@ jobs:
 
       # set up caching (duplicated verbatim below)
 
-      - name: Cache cargo registry
-        uses: actions/cache@v2
+      - uses: Swatinem/rust-cache@v1
         with:
-          path: ~/.cargo/registry
-          key: ${{runner.os}}-cargo-registry-${{hashFiles('Cargo.lock')}}
-          restore-keys: ${{runner.os}}-cargo-registry-
-      - name: Cache cargo git index
-        uses: actions/cache@v2
-        with:
-          path: ~/.cargo/git
-          key: ${{runner.os}}-cargo-git-${{hashFiles('Cargo.lock')}}
-          restore-keys: ${{runner.os}}-cargo-git-
-      - name: Cache cargo build
-        uses: actions/cache@v2
-        with:
-          path: target
-          key: ${{runner.os}}-cargo-target-${{hashFiles('Cargo.lock')}}-${{hashFiles('**/Cargo.toml')}}-${{hashFiles('**/*.rs')}}
-          restore-keys: |
-            ${{runner.os}}-cargo-target-${{hashFiles('Cargo.lock')}}-
-            ${{runner.os}}-cargo-target-
+          key: ${{ matrix.style }}v1 # increment this to bust the cache if needed
 
       # start the real work
 

--- a/enclone_core/src/defs.rs
+++ b/enclone_core/src/defs.rs
@@ -89,7 +89,7 @@ pub struct OriginInfo {
     pub alt_bc_fields: Vec<Vec<(String, HashMap<String, String>)>>,
     pub cells_cellranger: Vec<Option<usize>>,
     pub mean_read_pairs_per_cell_cellranger: Vec<Option<usize>>,
-    // map dataset index to a map of barcode to (secreted, membrane) UMI counts
+    // map dataset index to a map of barcode to (secreted, membrane) UMI counts:
     pub secmem: Vec<HashMap<String, (usize, usize)>>,
 }
 

--- a/pages/auto/cellranger.html
+++ b/pages/auto/cellranger.html
@@ -258,7 +258,7 @@ nucleotide identity on heavy chain CDR1+CDR2 (combined), then the join is reject
 
 <tr>
 <td> Mar. 11, 2022 </td>
-<td> <code>******</code> </td>
+<td> <code>e81193</code> </td>
 <td> 7.1 </td>
 <td>
 Two more changes to the join algorithm.

--- a/pages/cellranger.html.src
+++ b/pages/cellranger.html.src
@@ -224,7 +224,7 @@ nucleotide identity on heavy chain CDR1+CDR2 (combined), then the join is reject
 
 <tr>
 <td> Mar. 11, 2022 </td>
-<td> <code>******</code> </td>
+<td> <code>e81193</code> </td>
 <td> 7.1 </td>
 <td>
 Two more changes to the join algorithm.


### PR DESCRIPTION
- Fill in git hash on cellranger page.
- Switch to a more recent caching mechanism for GitHub Actions, and turn it on for Mac.   Note
  that previously we observed cryptic failures with Mac caching, and this could recur.
  
STATUS: ./test passes.