### PR TITLE
various changes (= dj/355)

### DIFF
--- a/enclone_exec/src/bin/enclone.rs
+++ b/enclone_exec/src/bin/enclone.rs
@@ -162,7 +162,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 evh.svg_hist_uniq.push(svg.clone());
                 evh.svg_history.push(0);
-
                 let dataset_names = &res.outs.dataset_names;
                 let metrics0 = &res.outs.metrics;
                 let mut metrics = Vec::<Vec<String>>::new();
@@ -193,7 +192,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     metrics_condensed: false,
                 };
                 let summary = s.pack();
-
                 evh.summary_hist_uniq.push(summary);
                 evh.summary_history.push(0);
                 let mut args2 = Vec::<String>::new();

--- a/enclone_exec/src/bin/enclone.rs
+++ b/enclone_exec/src/bin/enclone.rs
@@ -156,7 +156,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let ctl = &res.inter.setup.ctl;
             if ctl.gen_opt.vis_dump {
                 let mut evh = EncloneVisualHistory::default();
-                let mut svg = String::new();
+                let mut svg = enclone_visual::blank_svg();
                 if !res.outs.svgs.is_empty() {
                     svg = res.outs.svgs.last().unwrap().clone();
                 }

--- a/enclone_exec/tests/enclone_test4.rs
+++ b/enclone_exec/tests/enclone_test4.rs
@@ -70,7 +70,7 @@ fn test_cpu_usage() {
             gi = line.force_f64() / 1_000_000_000.0;
         }
     }
-    const REQUIRED_GI: f64 = 68.2890;
+    const REQUIRED_GI: f64 = 66.9112;
     let err = ((gi - REQUIRED_GI) / REQUIRED_GI).abs();
     let report = format!(
         "Observed GI = {:.4}, versus required GI = {:.4}, err = {:.2}%, versus max \

--- a/enclone_tail/src/group.rs
+++ b/enclone_tail/src/group.rs
@@ -768,7 +768,9 @@ pub fn group_and_print_clonotypes(
         &refdata,
     );
     *summary = stringme(&slog);
-    logx.append(&mut slog);
+    if ctl.gen_opt.summary {
+        logx.append(&mut slog);
+    }
 
     // Print to stdout.
 

--- a/enclone_tail/src/print_stats.rs
+++ b/enclone_tail/src/print_stats.rs
@@ -220,7 +220,7 @@ pub fn print_stats(
         sdx.push((sd[i].0, sd[i].1, j - i));
         i = j;
     }
-    if ctl.gen_opt.summary {
+    if ctl.gen_opt.summary || ctl.gen_opt.vis_dump {
         fwriteln!(logx, "\nSUMMARY STATISTICS");
         fwriteln!(logx, "1. overall");
         fwriteln!(logx, "   • number of datasets = {}", ctl.origin_info.n());

--- a/enclone_visual/src/summary.rs
+++ b/enclone_visual/src/summary.rs
@@ -327,9 +327,7 @@ pub fn summary(slf: &mut gui_structures::EncloneVisual) -> Element<Message> {
 
     // Determine initial font size.
 
-    let mut sum = "The summary is empty.  Usually this happens if the command failed,\n\
-            or if you used the VIS_DUMP argument without the SUMMARY argument."
-        .to_string();
+    let mut sum = "The summary is empty.  Usually this happens if the command failed.".to_string();
     if !hets.is_empty() {
         sum = hets[0].content.clone();
     }

--- a/test
+++ b/test
@@ -132,7 +132,7 @@ set elapsed = `expr $end - $start`
 ##### FAIL IF TOO MUCH TIME USED #####
 
 echo "\ntest compile time = $compile_elapsed seconds"
-set expected = 140
+set expected = 134
 set fudge_num = 11
 set fudge_den = 10
 set expected_plus_times = `expr $expected \* $fudge_num`

--- a/test
+++ b/test
@@ -132,7 +132,7 @@ set elapsed = `expr $end - $start`
 ##### FAIL IF TOO MUCH TIME USED #####
 
 echo "\ntest compile time = $compile_elapsed seconds"
-set expected = 148
+set expected = 140
 set fudge_num = 11
 set fudge_den = 10
 set expected_plus_times = `expr $expected \* $fudge_num`


### PR DESCRIPTION
- Fix bug in handling of blank svg for VIS_DUMP.
- Always generate summary for VIS_DUMP.
- Reset cycle count test and ./test wallclock to use values obtained on the standard 10x server.

STATUS: ./test, enclone.test and test_vis pass.  CI passes.  Also tested that branch compiles and ./test
runs successfully on Mac/M1 Pro (except for total wallclock, as expected).  Will release and test on 
Windows and add additional comment if there is a problem.